### PR TITLE
fix(cilium): update OCIRepository to v1.19.0

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.18.6
+    tag: 1.19.0
   url: oci://ghcr.io/home-operations/charts-mirror/cilium


### PR DESCRIPTION
## Summary

Update Cilium OCIRepository tag from `1.18.6` to `1.19.0`.

## Problem

PR #1062 updated `kubernetes/bootstrap/apps/helmfile.yaml` but Flux uses `kubernetes/apps/kube-system/cilium/app/ocirepository.yaml` for upgrades.

Bootstrap helmfile is only used for initial install. After that, the HelmRelease pulls from the OCIRepository.

## Changes

```yaml
# kubernetes/apps/kube-system/cilium/app/ocirepository.yaml
spec:
  ref:
-    tag: 1.18.6
+    tag: 1.19.0
```

## Impact

- Fixes L2 announcement issues
- Deploys Cilium 1.19.0 (currently running 1.18.6)
- Restores connectivity to alertmanager.altena.io and other internal services
