### PR TITLE
fix(renovate): add OCIRepository tag field detection

### DIFF
--- a/.renovate/customManagers.json5
+++ b/.renovate/customManagers.json5
@@ -21,6 +21,15 @@
       "fileMatch": ["\\.yaml(?:\\.j2)?$"],
       "matchStrings": ["oci://(?<depName>[^:]+):(?<currentValue>\\S+)"],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": ["Process OCIRepository tag field"],
+      "fileMatch": ["\\.yaml(?:\\.j2)?$"],
+      "matchStrings": [
+        "kind: OCIRepository[\\s\\S]*?url: oci://(?<depName>[^\\s]+)[\\s\\S]*?tag: (?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
## Problem

Renovate created PR #1062 to update Cilium from 1.18.6 → 1.19.0, but only updated the bootstrap helmfile:
- ✅ `kubernetes/bootstrap/apps/helmfile.yaml` updated
- ❌ `kubernetes/apps/kube-system/cilium/app/ocirepository.yaml` NOT updated

Flux uses the OCIRepository after initial install, not the bootstrap helmfile. This caused version drift.

## Root Cause

Renovate's OCI regex only matches inline tags:
```yaml
oci://image:1.18.6  # ← Detected
```

Flux OCIRepository uses a separate tag field:
```yaml
kind: OCIRepository
spec:
  url: oci://ghcr.io/.../cilium
  ref:
    tag: 1.18.6  # ← NOT detected
```

## Solution

Add custom manager regex to detect the OCIRepository pattern:

```json5
{
  "customType": "regex",
  "description": ["Process OCIRepository tag field"],
  "fileMatch": ["\\.yaml(?:\\.j2)?$"],
  "matchStrings": [
    "kind: OCIRepository[\\s\\S]*?url: oci://(?<depName>[^\\s]+)[\\s\\S]*?tag: (?<currentValue>[^\\s]+)"
  ],
  "datasourceTemplate": "docker"
}
```

## Impact

- ✅ Renovate will now detect OCIRepository updates
- ✅ Prevents version drift between helmfile and OCIRepository
- ✅ Future Cilium (and other OCI-based) updates will update BOTH files

## Testing

After merge, Renovate should detect that `ocirepository.yaml` is now on 1.19.0 (already merged in PR #1075).

Future updates will create PRs for both helmfile AND ocirepository.
