### PR TITLE
fix(cilium): switch to official OCI repository

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 1.19.0
-  url: oci://ghcr.io/home-operations/charts-mirror/cilium
+  url: oci://quay.io/cilium/charts/cilium


### PR DESCRIPTION
## Problem

OCIRepository fails to pull Cilium 1.19.0:

```
MANIFEST_UNKNOWN: manifest unknown
GET https://ghcr.io/v2/home-operations/charts-mirror/cilium/manifests/1.19.0
```

The onedr0p mirror repository does not have v1.19.0 yet (only has 1.18.6).

## Solution

Switch to official Cilium OCI repository:

```diff
- url: oci://ghcr.io/home-operations/charts-mirror/cilium
+ url: oci://quay.io/cilium/charts/cilium
```

## Impact

- ✅ Cilium 1.19.0 can now be pulled
- ✅ OCIRepository will reconcile successfully
- ✅ HelmRelease will upgrade Cilium pods
- ✅ Fixes L2 announcement issues

## Note

Can switch back to mirror repo once onedr0p adds 1.19.0 to his mirror.
