### PR TITLE
fix(cilium): expand L2 announcement interface pattern

### DIFF
--- a/kubernetes/apps/kube-system/cilium/config/cilium-l2.yaml
+++ b/kubernetes/apps/kube-system/cilium/config/cilium-l2.yaml
@@ -8,7 +8,7 @@ spec:
   externalIPs: true
   loadBalancerIPs: true
   interfaces:
-    - ^enp.*
+    - ^(enp|eno|eth).*
   nodeSelector:
     matchLabels:
       kubernetes.io/os: linux


### PR DESCRIPTION
## Problem

L2 announcements not working despite Cilium 1.19.0 + correct API version.

LoadBalancer IPs assigned but not announced:
- alertmanager.altena.io unreachable
- grafana.altena.io unreachable
- All envoy-internal services down

L2 responder errors in logs:
```
Error(s) while full reconciling l2 responder map
delete 192.168.1.130@4088: delete: key does not exist
```

## Root Cause

Interface pattern in CiliumL2AnnouncementPolicy:
```yaml
interfaces:
  - ^enp.*  # Only matches enp0, enp1, etc.
```

Talos nodes typically use **eno*** or **eth*** interfaces, not enp*.

## Solution

Expand pattern to match all common types:
```yaml
interfaces:
  - ^(enp|eno|eth).*
```

## Impact

- L2 responder will find network interfaces
- LoadBalancer IPs will be announced via ARP
- Internal services become reachable
