### PR TITLE
fix(cilium): enable device selection for L2 announcements

### DIFF
--- a/kubernetes/apps/kube-system/cilium/app/helm-values.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helm-values.yaml
@@ -15,8 +15,8 @@ gatewayAPI:
   enabled: false
 cni:
   exclusive: false
-# NOTE: devices might need to be set if you have more than one active NIC on your hosts
-# devices: eno+ eth+
+# Explicit device selection required for L2 announcements on Talos nodes
+devices: enp+
 endpointRoutes:
   enabled: true
 hubble:


### PR DESCRIPTION
## Problem

LoadBalancer IPs (envoy-internal at 192.168.1.130) were unreachable after Cilium v1.19.0 upgrade.

## Root Cause

Cilium L2 announcements require explicit device selection via the `devices` Helm value. Without it, the L2 responder does not announce on any interfaces.

From Cilium docs:
> L2 announcements only work if the selected devices are also part of the set of devices specified in the devices Helm option.

## Solution

Enable `devices: enp+` to match all Talos node interfaces (enp1s0, enp1s0.20, etc.).

## Testing

After merge + Flux reconciliation:
- [ ] Verify Cilium pods restart
- [ ] Check `ping 192.168.1.130` succeeds
- [ ] Test `curl https://alertmanager.altena.io`
- [ ] Verify no L2 responder errors in Cilium logs

## References

- [Cilium L2 Announcements Docs](https://docs.cilium.io/en/v1.19/network/l2-announcements/)
- Related: #1074 (CiliumLoadBalancerIPPool API upgrade)