### PR TITLE
fix: reduce memory limits to resolve overcommit warning

### DIFF
--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -90,7 +90,7 @@ spec:
                 cpu: 150m
                 memory: 256Mi
               limits:
-                memory: 8192Mi
+                memory: 2Gi
             securityContext:
               runAsUser: 2000
               runAsGroup: 2000

--- a/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/sabnzbd/app/helmrelease.yaml
@@ -64,7 +64,7 @@ spec:
                 cpu: 5m
                 memory: 256Mi
               limits:
-                memory: 12Gi
+                memory: 2Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true

--- a/kubernetes/apps/selfhosted/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/paperless/app/helmrelease.yaml
@@ -75,7 +75,7 @@ spec:
                 cpu: 25m
                 memory: 512Mi
               limits:
-                memory: 6Gi
+                memory: 2Gi
 
       redis:
         containers:


### PR DESCRIPTION
Reduce excessive memory limits to fix KubeMemoryOvercommit alert.

- sabnzbd: 12Gi → 2Gi (actual usage ~300Mi)
- qbittorrent: 8Gi → 2Gi (actual usage ~400Mi)
- paperless: 6Gi → 2Gi (actual usage ~200Mi)

Limits were 20-40x higher than actual usage. This reduces cluster memory overcommit from 332% to ~150%.