### PR TITLE
fix(zigbee2mqtt): update channel to match coordinator adapter

### DIFF
--- a/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/zigbee2mqtt/app/helmrelease.yaml
@@ -30,7 +30,7 @@ spec:
             env:
               Z2M_WATCHDOG: default
               ZIGBEE2MQTT_DATA: /data
-              ZIGBEE2MQTT_CONFIG_ADVANCED_CHANNEL: 20
+              ZIGBEE2MQTT_CONFIG_ADVANCED_CHANNEL: 25
               ZIGBEE2MQTT_CONFIG_ADVANCED_EXT_PAN_ID:
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
Coordinator adapter reports channel 25, config was set to 20. Causes startup failure.

Also requires 1Password update for zigbee2mqtt item:
- config_pan_id: 42308
- config_ext_pan_id: 8600977dc5e6c041
- config_network_key: 23f73552af68ff9e315cb106156e9b42

After both changes zigbee2mqtt will start without re-pairing devices.