### PR TITLE
fix(security): add keycloak to kustomization resources

### DIFF
--- a/kubernetes/apps/security/kustomization.yaml
+++ b/kubernetes/apps/security/kustomization.yaml
@@ -5,5 +5,6 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./external-secrets/ks.yaml
+  - ./keycloak/ks.yaml
   - ./onepassword-connect/ks.yaml
   - ./trivy-operator/ks.yaml


### PR DESCRIPTION
Keycloak ks.yaml exists but was not included in kubernetes/apps/security/kustomization.yaml resources list.

Without this, Flux cannot discover and reconcile the Keycloak Kustomization.