### PR TITLE
fix(keycloak): correct OCIRepository URL path

### DIFF
--- a/kubernetes/apps/security/keycloak/app/ocirepository.yaml
+++ b/kubernetes/apps/security/keycloak/app/ocirepository.yaml
@@ -7,6 +7,6 @@ metadata:
 spec:
   interval: 12h
   provider: generic
-  url: oci://ghcr.io/bjw-s-labs/helm-charts/app-template
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template
   ref:
     semver: 4.x


### PR DESCRIPTION
Fix OCIRepository URL from helm-charts to helm (correct path for bjw-s app-template)