### PR TITLE
fix(keycloak): remove --optimized flag for first start

### DIFF
--- a/kubernetes/apps/security/keycloak/app/helmrelease.yaml
+++ b/kubernetes/apps/security/keycloak/app/helmrelease.yaml
@@ -41,7 +41,6 @@ spec:
               - /opt/keycloak/bin/kc.sh
             args:
               - start
-              - --optimized
               - --proxy-headers=xforwarded
               - --http-enabled=true
               - --http-port=8080


### PR DESCRIPTION
The --optimized flag cannot be used on first startup. Keycloak requires a build first or starting without this flag.