### PR TITLE
fix(keycloak): correct startup args per docs

### DIFF
--- a/kubernetes/apps/security/keycloak/app/helmrelease.yaml
+++ b/kubernetes/apps/security/keycloak/app/helmrelease.yaml
@@ -41,12 +41,10 @@ spec:
               - /opt/keycloak/bin/kc.sh
             args:
               - start
-              - --optimized
-              - --proxy-headers=xforwarded
               - --http-enabled=true
               - --http-port=8080
-              - --hostname-strict=false
-              - --hostname=sso.${CLUSTER_DOMAIN}
+              - --hostname=https://sso.${CLUSTER_DOMAIN}
+              - --proxy-headers=xforwarded
               - --log-level=INFO
             env:
               JAVA_OPTS_APPEND: -Djgroups.dns.query=keycloak-headless


### PR DESCRIPTION
Fixed Keycloak startup configuration based on official docs:

- Removed `--optimized` flag (requires explicit build step first)
- Changed `--hostname` to full URL format (required with proxy-headers)
- Removed `--hostname-strict=false` (default is false when hostname is set)
- Reordered args for clarity

Keycloak docs references:
- https://www.keycloak.org/server/configuration
- https://www.keycloak.org/server/hostname