### PR TITLE
feat: add CRD schema extraction workflow

### DIFF
--- a/.github/workflows/schemas.yaml
+++ b/.github/workflows/schemas.yaml
@@ -1,0 +1,47 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: "Schemas"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    branches: ["main"]
+    paths:
+      - .github/workflows/schemas.yaml
+
+permissions:
+  contents: read
+
+jobs:
+  schemas:
+    name: Extract CRD Schemas
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: 3.x
+
+      - name: Setup Node
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: 22.x
+
+      - name: Install Python Dependencies
+        run: pip install pyyaml
+
+      - name: Extract CRD Schemas
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/Utilities/crd-extractor.sh | bash -s -- kubernetes/
+
+      - name: Upload Schemas
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        with:
+          name: schemas
+          path: schemas/
+          retention-days: 7


### PR DESCRIPTION
Adds automated CRD schema extraction similar to onedr0p setup.

## What it does
- Runs daily at 00:00 UTC (01:00 CET)
- Extracts all CRD schemas from kubernetes/ directory
- Uploads schemas as GitHub artifacts (7-day retention)

## Benefits
- Better IDE autocomplete for K8s custom resources
- Catch validation errors earlier
- Keep schemas in sync with cluster CRDs

## Simplified vs onedr0p
- No Cloudflare R2 dependency (uses GitHub artifacts instead)
- Simpler setup, works out of the box
- Can extend later if you want public schema hosting