### PR TITLE
fix(grafana): update kustomization reference

### DIFF
--- a/kubernetes/apps/observability/kustomization.yaml
+++ b/kubernetes/apps/observability/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./blackbox-exporter/ks.yaml
-  - ./grafana/ks.yaml
+  - ./grafana-operator/ks.yaml
   - ./kube-prometheus-stack/ks.yaml
   - ./kromgo/ks.yaml
   - ./loki/ks.yaml


### PR DESCRIPTION
Fixes cluster-apps kustomization error after Grafana Operator migration.

Change `./grafana/ks.yaml` → `./grafana-operator/ks.yaml` in observability kustomization.