### PR TITLE
fix: resolve system-upgrade PodSecurity blocking and improve automerge

### DIFF
--- a/.renovate/autoMerge.json5
+++ b/.renovate/autoMerge.json5
@@ -49,6 +49,14 @@
       "matchUpdateTypes": ["minor", "patch"],
       "matchPackagePatterns": ["/external-dns/", "/gateway-api/", "/prometheus-operator/"],
       "ignoreTests": true
+    },
+    {
+      "description": ["Auto-merge all non-breaking container updates"],
+      "matchDatasources": ["docker"],
+      "automerge": true,
+      "automergeType": "pr",
+      "matchUpdateTypes": ["minor", "patch"],
+      "ignoreTests": false
     }
   ]
 }

--- a/kubernetes/apps/system-upgrade/namespace.yaml
+++ b/kubernetes/apps/system-upgrade/namespace.yaml
@@ -3,6 +3,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: system-upgrade
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
     volsync.backube/privileged-movers: "true"

--- a/kubernetes/apps/system-upgrade/system-upgrade-controller/plans/talos.yaml
+++ b/kubernetes/apps/system-upgrade/system-upgrade-controller/plans/talos.yaml
@@ -19,6 +19,7 @@ spec:
       ignoreUpdates: true
   serviceAccountName: system-upgrade-controller
   upgrade:
+    # renovate: datasource=docker depName=ghcr.io/jfroy/tnu
     image: ghcr.io/jfroy/tnu:0.4.4
     args:
       - --node=$(SYSTEM_UPGRADE_NODE_NAME)


### PR DESCRIPTION
## Summary
- Add `privileged` PodSecurity labels to `system-upgrade` namespace — upgrade pods require `hostNetwork`, `hostPID`, `hostPath`, `CAP_SYS_BOOT` which were being blocked by `baseline:latest` enforcement
- Add Renovate tracking comment for `ghcr.io/jfroy/tnu` image in talos upgrade plan
- Add catch-all automerge rule for all non-breaking (minor+patch) container updates

## Root cause
All upgrade jobs were failing with `DeadlineExceeded` because the pods could never be created due to PodSecurity violations:
```
pods "apply-talos-on-baldur-..." is forbidden: violates PodSecurity "baseline:latest"
```