### PR TITLE
feat: migrate system-upgrade-controller to tuppr

### DIFF
--- a/.renovate/groups.json5
+++ b/.renovate/groups.json5
@@ -81,10 +81,10 @@
       "separateMinorPatch": true
     },
     {
-      "description": ["System Upgrade Controller"],
-      "groupName": "System Upgrade Controller",
-      "matchPackagePatterns": ["system-upgrade-controller"],
-      "matchDatasources": ["docker", "github-releases"],
+      "description": ["Tuppr"],
+      "groupName": "Tuppr",
+      "matchPackagePatterns": ["tuppr"],
+      "matchDatasources": ["docker"],
       "group": {
         "commitMessageTopic": "{{{groupName}}} group"
       }

--- a/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/helmrelease.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tuppr
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: tuppr
+  interval: 30m
+  values:
+    replicaCount: 2

--- a/kubernetes/apps/system-upgrade/tuppr/app/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/kustomization.yaml
@@ -3,5 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./tuppr/ks.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: tuppr
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    # renovate: datasource=docker depName=ghcr.io/home-operations/charts/tuppr
+    tag: 0.1.2
+  url: oci://ghcr.io/home-operations/charts/tuppr

--- a/kubernetes/apps/system-upgrade/tuppr/ks.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/ks.yaml
@@ -1,0 +1,40 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tuppr
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  interval: 30m
+  path: ./kubernetes/apps/system-upgrade/tuppr/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: system-upgrade
+  wait: true
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tuppr-upgrades
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: tuppr
+  interval: 30m
+  path: ./kubernetes/apps/system-upgrade/tuppr/upgrades
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: system-upgrade
+  wait: false

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/tuppr.home-operations.com/kubernetesupgrade_v1alpha1.json
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: KubernetesUpgrade
+metadata:
+  name: kubernetes
+spec:
+  kubernetes:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
+    version: v1.35.2

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kustomization.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kustomization.yaml
@@ -3,5 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./tuppr/ks.yaml
+  - ./kubernetesupgrade.yaml
+  - ./talosupgrade.yaml

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/tuppr.home-operations.com/talosupgrade_v1alpha1.json
+apiVersion: tuppr.home-operations.com/v1alpha1
+kind: TalosUpgrade
+metadata:
+  name: talos
+spec:
+  talos:
+    # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
+    version: v1.12.6
+  policy:
+    rebootMode: default


### PR DESCRIPTION
## Summary
- Replace system-upgrade-controller + tnu with [tuppr](https://github.com/home-operations/tuppr) for Talos/Kubernetes upgrades
- Update Renovate group config from system-upgrade-controller to tuppr

## Why
The old setup (system-upgrade-controller + tnu) failed because upgrade pods run with `hostNetwork: true` and couldn't reach the Talos API via ClusterIP. Both bjw-s-labs/home-ops and onedr0p/home-ops have migrated to tuppr which handles this natively.

## Old resources to clean up after merge
The old system-upgrade-controller Flux kustomizations will be pruned automatically. The old `system-upgrade-controller/` directory can be removed in a follow-up commit.