### PR TITLE
feat(selfhosted): add OpenClaw with Moonshot provider

### DIFF
--- a/kubernetes/apps/selfhosted/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - ./actual-finance/ks.yaml
   - ./mealie/ks.yaml
   - ./n8n/ks.yaml
+  - ./openclaw/ks.yaml
   - ./paperless/ks.yaml
   - ./semaphore/ks.yaml

--- a/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-config
+data:
+  openclaw.json: |
+    {
+      "provider": "moonshot",
+      "defaultModel": {
+        "id": "moonshot/kimi-k2-0905",
+        "contextWindow": 262144
+      },
+      "gateway": {
+        "host": "127.0.0.1",
+        "port": 18789
+      },
+      "browser": {
+        "enabled": false
+      }
+    }

--- a/kubernetes/apps/selfhosted/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/externalsecret.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openclaw
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: openclaw-secrets
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: openclaw

--- a/kubernetes/apps/selfhosted/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/helmrelease.yaml
@@ -1,0 +1,107 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: openclaw
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: openclaw
+  interval: 30m
+  values:
+    controllers:
+      openclaw:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        pod:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            fsGroup: 1000
+            fsGroupChangePolicy: "OnRootMismatch"
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/openclaw/openclaw
+              tag: v2026.4.11
+            envFrom:
+              - secretRef:
+                  name: openclaw-secrets
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: &port 18789
+                  periodSeconds: 30
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  tcpSocket:
+                    port: *port
+                  periodSeconds: 10
+                  failureThreshold: 3
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 5
+            resources:
+              requests:
+                cpu: 200m
+                memory: 512Mi
+              limits:
+                cpu: 1000m
+                memory: 1Gi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                  - ALL
+
+    service:
+      app:
+        forceRename: openclaw
+        primary: true
+        ports:
+          http:
+            port: *port
+
+    route:
+      app:
+        hostnames:
+          - openclaw.valhalla.local
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+
+    persistence:
+      config:
+        type: persistentVolumeClaim
+        storageClass: ceph-filesystem
+        size: 5Gi
+        accessMode: ReadWriteMany
+        globalMounts:
+          - path: /home/node/.openclaw
+      openclaw-json:
+        type: configMap
+        name: openclaw-config
+        advancedMounts:
+          openclaw:
+            app:
+              - path: /home/node/.openclaw/openclaw.json
+                subPath: openclaw.json
+                readOnly: true

--- a/kubernetes/apps/selfhosted/openclaw/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./configmap.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./networkpolicy.yaml

--- a/kubernetes/apps/selfhosted/openclaw/app/networkpolicy.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/networkpolicy.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: openclaw
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: openclaw
+  ingress:
+    - fromEndpoints:
+        - matchLabels:
+            gateway.networking.k8s.io/gateway-name: envoy-internal
+            io.kubernetes.pod.namespace: network
+      toPorts:
+        - ports:
+            - port: "18789"
+              protocol: TCP
+  egress:
+    - toEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+            k8s-app: kube-dns
+      toPorts:
+        - ports:
+            - port: "53"
+              protocol: UDP
+            - port: "53"
+              protocol: TCP
+    - toCIDRSet:
+        - cidr: 0.0.0.0/0
+          exceptCIDRs:
+            - 10.0.0.0/8
+            - 172.16.0.0/12
+            - 192.168.0.0/16
+      toPorts:
+        - ports:
+            - port: "443"
+              protocol: TCP

--- a/kubernetes/apps/selfhosted/openclaw/app/ocirepository.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: openclaw
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/selfhosted/openclaw/ks.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/ks.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app openclaw
+  namespace: flux-system
+spec:
+  targetNamespace: selfhosted
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+    - name: rook-ceph-cluster
+  path: ./kubernetes/apps/selfhosted/openclaw/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## Summary
- OpenClaw deployment in selfhosted namespace
- Moonshot provider with kimi-k2-0905 model (262k context)
- CephFS 5Gi PVC for persistent config
- CiliumNetworkPolicy: ingress from envoy only, egress to DNS + public HTTPS
- ExternalSecret for MOONSHOT_API_KEY and OPENCLAW_GATEWAY_TOKEN
- HTTPRoute at openclaw.valhalla.local via envoy-internal

## Prerequisites
- 1Password item "openclaw" with fields: moonshot-api-key, gateway-token