### PR TITLE
fix(openclaw): correct CiliumNetworkPolicy field name

### DIFF
--- a/kubernetes/apps/selfhosted/openclaw/app/networkpolicy.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/networkpolicy.yaml
@@ -29,7 +29,7 @@ spec:
               protocol: TCP
     - toCIDRSet:
         - cidr: 0.0.0.0/0
-          exceptCIDRs:
+          except:
             - 10.0.0.0/8
             - 172.16.0.0/12
             - 192.168.0.0/16


### PR DESCRIPTION
Fix `exceptCIDRs` → `except` in CiliumNetworkPolicy schema.