### PR TITLE
fix(openclaw): correct image tag (no v prefix)

### DIFF
--- a/kubernetes/apps/selfhosted/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
           app:
             image:
               repository: ghcr.io/openclaw/openclaw
-              tag: v2026.4.11
+              tag: 2026.4.12
             envFrom:
               - secretRef:
                   name: openclaw-secrets


### PR DESCRIPTION
Image tags on ghcr.io/openclaw/openclaw don't use the v prefix.