### PR TITLE
fix(openclaw): use altena.io hostname

### DIFF
--- a/kubernetes/apps/selfhosted/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/helmrelease.yaml
@@ -78,7 +78,7 @@ spec:
     route:
       app:
         hostnames:
-          - openclaw.valhalla.local
+          - openclaw.altena.io
         parentRefs:
           - name: envoy-internal
             namespace: network


### PR DESCRIPTION
Change HTTPRoute hostname from openclaw.valhalla.local to openclaw.altena.io so external-dns picks it up.