### PR TITLE
fix(openclaw): bind to 0.0.0.0 for service access

### DIFF
--- a/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
@@ -8,7 +8,7 @@ data:
     {
       "gateway": {
         "port": 18789,
-        "bind": "127.0.0.1",
+        "bind": "0.0.0.0",
         "auth": {
           "token": "${OPENCLAW_GATEWAY_TOKEN}"
         }


### PR DESCRIPTION
127.0.0.1 only accepts localhost connections inside the pod. Envoy needs to reach it via the service, so bind to 0.0.0.0.