### PR TITLE
fix(openclaw): whitelist altena.io origin in controlUi

### DIFF
--- a/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
@@ -11,6 +11,11 @@ data:
         "bind": "0.0.0.0",
         "auth": {
           "token": "${OPENCLAW_GATEWAY_TOKEN}"
+        },
+        "controlUi": {
+          "allowedOrigins": [
+            "https://openclaw.altena.io"
+          ]
         }
       },
       "agents": {


### PR DESCRIPTION
Add openclaw.altena.io to gateway.controlUi.allowedOrigins so the dashboard can connect via the HTTPRoute.