### PR TITLE
feat(openclaw): add valhalla + sport agents with Discord routing

### DIFF
--- a/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
@@ -18,6 +18,24 @@ data:
           ]
         }
       },
+      "channels": {
+        "discord": {
+          "enabled": true,
+          "defaultAccount": "inframan",
+          "accounts": {
+            "inframan": {
+              "enabled": true,
+              "name": "Inframan",
+              "token": "${DISCORD_INFRAMAN_TOKEN}"
+            },
+            "marja": {
+              "enabled": true,
+              "name": "Marja",
+              "token": "${DISCORD_MARJA_TOKEN}"
+            }
+          }
+        }
+      },
       "agents": {
         "defaults": {
           "model": {
@@ -25,7 +43,45 @@ data:
           }
         },
         "list": [
-          { "id": "main", "default": true }
+          {
+            "id": "main",
+            "default": true
+          },
+          {
+            "id": "valhalla",
+            "skills": [
+              "valhalla",
+              "discord"
+            ]
+          },
+          {
+            "id": "sport",
+            "skills": [
+              "sport",
+              "discord",
+              "weather"
+            ]
+          }
         ]
-      }
+      },
+      "bindings": [
+        {
+          "type": "route",
+          "agentId": "valhalla",
+          "match": {
+            "channel": "discord",
+            "accountId": "inframan"
+          },
+          "comment": "All traffic naar de inframan bot gaat naar de valhalla agent"
+        },
+        {
+          "type": "route",
+          "agentId": "sport",
+          "match": {
+            "channel": "discord",
+            "accountId": "marja"
+          },
+          "comment": "All traffic naar de marja bot gaat naar de sport agent"
+        }
+      ]
     }

--- a/kubernetes/apps/selfhosted/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/externalsecret.yaml
@@ -11,6 +11,14 @@ spec:
   target:
     name: openclaw-secrets
     creationPolicy: Owner
+  # NB: deze ExternalSecret gebruikt `extract` — alle keys uit het 1Password item
+  # "openclaw" worden envvars op de pod. Vereiste keys in dat item:
+  #   - OPENCLAW_GATEWAY_TOKEN    (bestaande)
+  #   - MOONSHOT_API_KEY          (bestaande)
+  #   - DISCORD_INFRAMAN_TOKEN    (NIEUW — bot token van de "inframan" Discord bot;
+  #                               gekoppeld aan de valhalla agent)
+  #   - DISCORD_MARJA_TOKEN       (NIEUW — bot token van de "Marja" Discord bot;
+  #                               gekoppeld aan de sport agent)
   dataFrom:
     - extract:
         key: openclaw

--- a/kubernetes/apps/selfhosted/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/helmrelease.yaml
@@ -10,6 +10,8 @@ spec:
     name: openclaw
   interval: 30m
   values:
+    defaultPodOptions:
+      serviceAccountName: openclaw
     controllers:
       openclaw:
         annotations:
@@ -104,4 +106,22 @@ spec:
             app:
               - path: /home/node/.openclaw/openclaw.json
                 subPath: openclaw.json
+                readOnly: true
+      skill-valhalla:
+        type: configMap
+        name: openclaw-skill-valhalla
+        advancedMounts:
+          openclaw:
+            app:
+              - path: /home/node/.openclaw/workspace/skills/valhalla/SKILL.md
+                subPath: SKILL.md
+                readOnly: true
+      skill-sport:
+        type: configMap
+        name: openclaw-skill-sport
+        advancedMounts:
+          openclaw:
+            app:
+              - path: /home/node/.openclaw/workspace/skills/sport/SKILL.md
+                subPath: SKILL.md
                 readOnly: true

--- a/kubernetes/apps/selfhosted/openclaw/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/kustomization.yaml
@@ -4,6 +4,9 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./configmap.yaml
+  - ./skills-valhalla.yaml
+  - ./skills-sport.yaml
+  - ./rbac.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
   - ./networkpolicy.yaml

--- a/kubernetes/apps/selfhosted/openclaw/app/networkpolicy.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/networkpolicy.yaml
@@ -27,6 +27,9 @@ spec:
               protocol: UDP
             - port: "53"
               protocol: TCP
+    # kubectl toegang naar kube-apiserver (voor valhalla agent)
+    - toEntities:
+        - kube-apiserver
     - toCIDRSet:
         - cidr: 0.0.0.0/0
           except:

--- a/kubernetes/apps/selfhosted/openclaw/app/rbac.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/rbac.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openclaw
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openclaw-selfhosted-reader
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - services
+      - endpoints
+      - configmaps
+      - events
+      - persistentvolumeclaims
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources:
+      - helmreleases
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources:
+      - kustomizations
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources:
+      - gitrepositories
+      - ocirepositories
+      - helmrepositories
+      - helmcharts
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openclaw-selfhosted-reader
+subjects:
+  - kind: ServiceAccount
+    name: openclaw
+    namespace: selfhosted
+roleRef:
+  kind: Role
+  name: openclaw-selfhosted-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/apps/selfhosted/openclaw/app/skills-sport.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/skills-sport.yaml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-skill-sport
+data:
+  SKILL.md: |
+    # Sport — hardlopen en afvallen
+
+    Je bent de sport en gezondheidsassistent.
+    Je helpt met hardlopen, trainingplanning, gewicht bijhouden en afvallen.
+
+    ## Scope
+
+    JIJ DOET: alles wat met sport, hardlopen, gewicht, voeding en gezondheid te maken heeft.
+    JIJ DOET NIET: infrastructuur, Kubernetes, servers, code — dat is een andere agent.
+
+    ## Context
+
+    - Doel: halve marathon voorbereiding, gewichtsafname
+    - Apparaat: Garmin (hartslag, afstand, tempo)
+    - Trainingsstructuur: track intervals, tempo runs, zone 2 lange duurlopen, krachttraining
+    - Tracker: vraag bij elke check-in naar actuele cijfers indien niet bekend
+
+    ## Voorbeeldvragen die bij jou horen
+
+    - "Hoe staat mijn trainingsweek ervoor?"
+    - "Wat moet ik vandaag doen?"
+    - "Ik heb [X] gelopen met [Y] hartslag, klopt dat?"
+    - "Hoeveel calorieën mag ik nog?"
+    - "Motiveer me even"
+    - "Ik ben [X] kg, klopt dat met mijn doel?"
+
+    ## Gedragsregels
+
+    - Houd bij wat er in het gesprek gezegd is over gewicht en trainingen
+    - Stel gerichte vragen als data ontbreekt
+    - Geen onnodige lezingen of moraliserend commentaar
+    - Geef concrete suggesties, geen vage adviezen
+    - Rapporteer in het Nederlands

--- a/kubernetes/apps/selfhosted/openclaw/app/skills-valhalla.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/skills-valhalla.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-skill-valhalla
+data:
+  SKILL.md: |
+    # Valhalla — cluster assistent
+
+    Je bent de infrastructuur assistent voor het Valhalla Kubernetes cluster.
+    Je reageert op vragen over de staat van het cluster, services en netwerk.
+    Je voert taken uit op het cluster wanneer daarom gevraagd wordt.
+
+    ## Scope
+
+    JIJ DOET: alles wat met Valhalla en de onderliggende infrastructuur te maken heeft.
+    JIJ DOET NIET: sport, gezondheid, afvallen, persoonlijke planning — dat is een andere agent.
+
+    ## Cluster
+
+    - Distro: Talos Linux
+    - Nodes: meerdere Dell OptiPlex nodes
+    - CNI: Cilium
+    - Storage: Rook-Ceph (CephFS en RBD)
+    - GitOps: FluxCD
+    - Ingress: Envoy Gateway met HTTPRoutes
+    - Secrets: External Secrets Operator + 1Password
+    - Monitoring: Prometheus + Grafana (indien beschikbaar)
+
+    ## Tools die je mag gebruiken
+
+    - kubectl (beperkt tot selfhosted namespace tenzij expliciet anders gevraagd)
+    - flux CLI voor sync status
+    - Lezen van logs en events
+
+    ## Voorbeeldvragen die bij jou horen
+
+    - "Hoe staat het cluster ervoor?"
+    - "Zijn er pods die crashen?"
+    - "Wat is de Ceph status?"
+    - "Sync jij mijn Flux kustomizations?"
+    - "Waarom is [service] niet bereikbaar?"
+    - "Hoeveel resources gebruikt [namespace]?"
+
+    ## Gedragsregels
+
+    - Geef altijd een korte samenvatting eerst, daarna details indien gevraagd
+    - Bij problemen: diagnose eerst, dan pas actie voorstellen
+    - Voer destructieve acties (delete, restart) alleen uit na expliciete bevestiging
+    - Rapporteer in het Nederlands tenzij technische output dit niet toelaat


### PR DESCRIPTION
## Summary
- Twee custom skills (`valhalla`, `sport`) via ConfigMaps in workspace
- Discord channel met twee bot-accounts (inframan, marja), tokens via 1Password env-refs
- Routing: inframan → valhalla agent, marja → sport agent
- ServiceAccount + Role/RoleBinding voor read-only kubectl in selfhosted
- CiliumNetworkPolicy egress naar kube-apiserver
- 1Password item vereist 2 nieuwe keys: `DISCORD_INFRAMAN_TOKEN`, `DISCORD_MARJA_TOKEN` (al aangemaakt)

## Test plan
- [ ] Flux reconcileert zonder errors
- [ ] Pod restart succesvol
- [ ] Discord bots loggen in (logs check)
- [ ] Inframan reageert in Discord als valhalla agent
- [ ] Marja reageert in Discord als sport agent