### PR TITLE
fix(openclaw): use env ref-object for token interpolation

### DIFF
--- a/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
@@ -10,7 +10,11 @@ data:
         "port": 18789,
         "bind": "0.0.0.0",
         "auth": {
-          "token": "${OPENCLAW_GATEWAY_TOKEN}"
+          "token": {
+            "source": "env",
+            "provider": "default",
+            "id": "OPENCLAW_GATEWAY_TOKEN"
+          }
         },
         "controlUi": {
           "allowedOrigins": [
@@ -26,12 +30,20 @@ data:
             "inframan": {
               "enabled": true,
               "name": "Inframan",
-              "token": "${DISCORD_INFRAMAN_TOKEN}"
+              "token": {
+                "source": "env",
+                "provider": "default",
+                "id": "DISCORD_INFRAMAN_TOKEN"
+              }
             },
             "marja": {
               "enabled": true,
               "name": "Marja",
-              "token": "${DISCORD_MARJA_TOKEN}"
+              "token": {
+                "source": "env",
+                "provider": "default",
+                "id": "DISCORD_MARJA_TOKEN"
+              }
             }
           }
         }


### PR DESCRIPTION
## Summary
- Follow-up on #1357 — Discord accounts zagen er "not configured" uit na boot
- Oorzaak: `${VAR}` shell-style placeholders worden niet geïnterpoleerd door OpenClaw
- Fix: gebruik de schema-compliant ref-object syntax voor alle tokens

## Test plan
- [ ] Flux reconcileert
- [ ] `openclaw agents list` toont beide Discord accounts als `configured`
- [ ] Inframan + Marja bots staan online in Discord