### PR TITLE
fix(openclaw): register default env secrets provider

### DIFF
--- a/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
@@ -6,6 +6,18 @@ metadata:
 data:
   openclaw.json: |
     {
+      "secrets": {
+        "providers": {
+          "default": {
+            "source": "env",
+            "allowlist": [
+              "OPENCLAW_GATEWAY_TOKEN",
+              "DISCORD_INFRAMAN_TOKEN",
+              "DISCORD_MARJA_TOKEN"
+            ]
+          }
+        }
+      },
       "gateway": {
         "port": 18789,
         "bind": "0.0.0.0",


### PR DESCRIPTION
Follow-up: token refs met provider `default` werden niet geresolved omdat de provider niet gedeclareerd was. Declareert `secrets.providers.default` met envvar allowlist.