### PR TITLE
fix(openclaw): configure moonshot provider + switch to kimi-k2.5

### DIFF
--- a/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
@@ -13,7 +13,8 @@ data:
             "allowlist": [
               "OPENCLAW_GATEWAY_TOKEN",
               "DISCORD_INFRAMAN_TOKEN",
-              "DISCORD_MARJA_TOKEN"
+              "DISCORD_MARJA_TOKEN",
+              "MOONSHOT_API_KEY"
             ]
           }
         }
@@ -60,10 +61,24 @@ data:
           }
         }
       },
+      "models": {
+        "mode": "merge",
+        "providers": {
+          "moonshot": {
+            "baseUrl": "https://api.moonshot.ai/v1",
+            "api": "openai-completions",
+            "apiKey": {
+              "source": "env",
+              "provider": "default",
+              "id": "MOONSHOT_API_KEY"
+            }
+          }
+        }
+      },
       "agents": {
         "defaults": {
           "model": {
-            "primary": "moonshot/kimi-k2-0905"
+            "primary": "moonshot/kimi-k2.5"
           }
         },
         "list": [


### PR DESCRIPTION
Model warmup faalde met `Unknown model: moonshot/kimi-k2-0905` — de Moonshot provider was niet gedeclareerd en `kimi-k2-0905` zit niet in de default catalog van OpenClaw 2026.4.12.

Declareert `models.providers.moonshot` (baseUrl + apiKey via env-ref) en switcht default model naar `moonshot/kimi-k2.5` (huidige stable, 262K context, tool-use).