### PR TITLE
fix(openclaw): let app-template chart generate ServiceAccount

### DIFF
--- a/kubernetes/apps/selfhosted/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/helmrelease.yaml
@@ -10,8 +10,9 @@ spec:
     name: openclaw
   interval: 30m
   values:
-    defaultPodOptions:
-      serviceAccountName: openclaw
+    serviceAccount:
+      openclaw:
+        enabled: true
     controllers:
       openclaw:
         annotations:

--- a/kubernetes/apps/selfhosted/openclaw/app/rbac.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/rbac.yaml
@@ -1,9 +1,6 @@
 ---
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: openclaw
----
+# ServiceAccount wordt door de bjw-s app-template chart gegenereerd via
+# values.serviceAccount.openclaw — zie helmrelease.yaml.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:


### PR DESCRIPTION
Unblocks the workspace mounts from #1362 — Helm upgrade was failing on `defaultPodOptions.serviceAccountName`.