### PR TITLE
fix(openclaw): disable privileged discord intents + enable debug logs

### DIFF
--- a/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
@@ -10,6 +10,10 @@ data:
         "enabled": true,
         "flags": ["discord.*"]
       },
+      "logging": {
+        "level": "debug",
+        "consoleLevel": "debug"
+      },
       "secrets": {
         "providers": {
           "default": {
@@ -42,6 +46,10 @@ data:
       "channels": {
         "discord": {
           "enabled": true,
+          "intents": {
+            "presence": false,
+            "guildMembers": false
+          },
           "defaultAccount": "inframan",
           "accounts": {
             "inframan": {


### PR DESCRIPTION
## Summary
Root cause van de stille \`awaiting gateway readiness\` hang:
1. Bots zijn als user-app geïnstalleerd (scope \`applications.commands\`), niet als guild-bot → Discord stuurt geen READY. Dave re-invite's ze met \`bot\` + \`applications.commands\` scopes.
2. OpenClaw vraagt standaard GUILD_MEMBERS + PRESENCE privileged intents; onze bots hebben alleen MESSAGE_CONTENT. Deze PR zet \`channels.discord.intents.{presence,guildMembers}: false\` zodat OpenClaw ze niet meer aanvraagt — onze agents hebben ze toch niet nodig.
3. \`logging.{level,consoleLevel}: debug\` voor toekomstige silent failures.

Volledig plan: \`~/.claude/plans/woolly-stargazing-bonbon.md\`

## Test plan
- [ ] Flux reconcile + HelmRelease reconcile succesvol
- [ ] Pod logs tonen \`[discord] logged in to discord as ... (inframan)\` en idem Marja
- [ ] \`openclaw channels status --probe\` toont beide accounts als configured
- [ ] \`@Inframan\` in Discord server triggert valhalla agent response
- [ ] \`@Marja\` in Discord server triggert sport agent response