### PR TITLE
fix(openclaw): open discord dm + group policies

### DIFF
--- a/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
@@ -50,6 +50,8 @@ data:
             "presence": false,
             "guildMembers": false
           },
+          "dmPolicy": "open",
+          "groupPolicy": "open",
           "defaultAccount": "inframan",
           "accounts": {
             "inframan": {


### PR DESCRIPTION
Bots waren connected+running maar negeerden alle berichten. Root cause: default `groupPolicy: allowlist` zonder configured allowlist = silent drop. Set both to `open` voor Dave's private server.