### PR TITLE
fix(openclaw): add discord allowFrom=['*'] required by open dmPolicy

### DIFF
--- a/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
@@ -52,6 +52,7 @@ data:
           },
           "dmPolicy": "open",
           "groupPolicy": "open",
+          "allowFrom": ["*"],
           "defaultAccount": "inframan",
           "accounts": {
             "inframan": {


### PR DESCRIPTION
Unblocks crashloop — schema requires allowFrom when dmPolicy=open.