### PR TITLE
fix(openclaw): explicit gateway command, mode, and memory limits

### DIFF
--- a/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/configmap.yaml
@@ -11,8 +11,8 @@ data:
         "flags": ["discord.*"]
       },
       "logging": {
-        "level": "debug",
-        "consoleLevel": "debug"
+        "level": "info",
+        "consoleLevel": "info"
       },
       "secrets": {
         "providers": {
@@ -28,6 +28,7 @@ data:
         }
       },
       "gateway": {
+        "mode": "local",
         "port": 18789,
         "bind": "lan",
         "auth": {

--- a/kubernetes/apps/selfhosted/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/openclaw/app/helmrelease.yaml
@@ -31,6 +31,13 @@ spec:
             image:
               repository: ghcr.io/openclaw/openclaw
               tag: 2026.4.15
+            command:
+              - /bin/sh
+              - -c
+              - exec node dist/index.js gateway --bind lan
+            env:
+              HOME: /home/node
+              OPENCLAW_GATEWAY_PORT: "18789"
             envFrom:
               - secretRef:
                   name: openclaw-secrets
@@ -59,10 +66,10 @@ spec:
             resources:
               requests:
                 cpu: 200m
-                memory: 512Mi
-              limits:
-                cpu: 1000m
                 memory: 1Gi
+              limits:
+                cpu: 2000m
+                memory: 2Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: false


### PR DESCRIPTION
## Summary
Aligned met joryirving/home-ops referentie-implementatie die werkend in prod draait:
- Explicit `command: node dist/index.js gateway --bind lan` (was: default entrypoint)
- `gateway.mode: "local"` (was: unset — doctor flagde dit als blocker)
- Memory 1Gi req / 2Gi limit (was: 512Mi/1Gi — OOMKilled na 3 dagen)
- Logging terug naar `info` (was debug → memory druk)

## Test plan
- [ ] Pod start zonder crash
- [ ] `openclaw channels status --probe` toont beide bots als connected+works
- [ ] `@inframan` en `@Marja` krijgen antwoord in Discord