### PR TITLE
fix(talos): tighten kubelet image GC thresholds

### DIFF
--- a/talos/patches/global/machine-kubelet.yaml
+++ b/talos/patches/global/machine-kubelet.yaml
@@ -3,6 +3,11 @@ machine:
   kubelet:
     extraConfig:
       serializeImagePulls: false
+      # Trigger image GC before ceph mon_data_avail_warn (30% free) fires
+      imageGCHighThresholdPercent: 70
+      imageGCLowThresholdPercent: 55
+      # Reap images unused for 7d regardless of disk pressure
+      imageMaximumGCAge: 168h
     nodeIP:
       validSubnets:
         - 192.168.1.0/24


### PR DESCRIPTION
## Summary

- Set `imageGCHighThresholdPercent: 70` (was default 85) so image GC starts before ceph's `mon_data_avail_warn` (30% free = 70% used) fires
- Set `imageGCLowThresholdPercent: 55` for headroom and to avoid thrashing
- Set `imageMaximumGCAge: 168h` to reap unused images after 7d regardless of disk pressure

## Why

Ceph has been alerting `CephMonDiskspaceLow` / `CephHealthWarning` roughly every 2 months. Root cause: kubelet's default image GC thresholds (85/80) never trigger before the ceph mon reports <30% free, so renovate-driven image churn piles up. Baldur had 478 redundant tag versions across 103 repos (e.g. 16 n8n tags, 12 semaphore tags, 9 booklore tags from an app that's already been removed from the repo).

The new thresholds close the gap so kubelet cleans up before ceph alerts, and `imageMaximumGCAge` forces eventual cleanup of stale tags from removed apps.

Already applied live to all 3 nodes via `talosctl apply-config --mode=no-reboot` — this PR just commits the source of truth in the talhelper patch.

## Test plan

- [ ] Verify `imageGCHighThresholdPercent: 70` in generated kubelet config on all 3 nodes
- [ ] Wait for next kubelet image-GC cycle; confirm baldur imageFs drops below 70%
- [ ] Confirm `CephMonDiskspaceLow` alert clears