### PR TITLE
feat(observability)!: upgrade kube-prometheus-stack to 84.0.0

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/ocirepository.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 82.18.0
+    tag: 84.0.0
   url: oci://ghcr.io/prometheus-community/charts/kube-prometheus-stack


### PR DESCRIPTION
## Summary

- Bump `kube-prometheus-stack` chart 82.18.0 → 84.0.0

## Why

Split from renovate's PR #1320 which bundled Loki 7.0.0 (GEL-only, see #1410). This half is the safe part.

## Breaking change review

Reviewed changelog from 82.18 → 84.0:

- **prometheus-operator 0.90.0** (included in chart 83.0.0): only [CHANGE/BUGFIX] entry is that it now validates remote-write URL scheme is `http` or `https`. We do not use `remoteWrite` (grep'd `kubernetes/apps/observability/`), so unaffected.
- **chart 84.0.0**: bumps Grafana to v12. Our Grafana config is vanilla — no custom datasource plugins beyond what ships in the Helm values.
- No CRD schema removals in 83.x / 84.x.

## Test plan

- [ ] Flux reconciles new chart version without HelmRelease drift
- [ ] All prometheus-operator CRDs re-applied cleanly
- [ ] Prometheus / Alertmanager / Grafana pods Running post-upgrade
- [ ] Alerts still firing/resolving as expected (current state: `CephHealthWarning` + `CephMonDiskspaceLow` firing from the kubelet-GC fix in #1411)
- [ ] Grafana dashboards render under v12