### PR TITLE
chore(renovate): pin Loki OSS chart to <7.0.0

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -29,6 +29,14 @@
       ],
       "matchPackageNames": ["ghcr.io/siderolabs/installer"],
       "automerge": false
+    },
+    {
+      "description": [
+        "Pin grafana/helm-charts Loki to <7.0.0 — chart 7.0.0 is GEL-only;",
+        "OSS distribution moved to grafana-community/helm-charts fork."
+      ],
+      "matchPackageNames": ["ghcr.io/grafana/helm-charts/loki"],
+      "allowedVersions": "<7.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add a renovate packageRule pinning `ghcr.io/grafana/helm-charts/loki` to `<7.0.0`

## Why

Prevents renovate from resurrecting the monitoring-stack major bundle (see closed #1320) that would pull Loki 7.0.0 — that chart release is maintained for Grafana Enterprise Logs only; OSS users are moving to the `grafana-community/helm-charts` fork in #1410.

Once #1410 merges and the OCIRepository URL switches to `grafana-community`, this rule becomes dead code but stays harmless because the package name no longer matches.

## Test plan

- [ ] Next renovate run does not recreate the Monitoring Stack major PR with Loki 7.0.0
- [ ] kube-prometheus-stack bumps continue to surface as a separate PR (Monitoring Stack group still matches kube-prom-stack)