### PR TITLE
fix(talos): revert kubelet to v1.35.4 and gate future bumps

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -12,6 +12,23 @@
       "matchDatasources": ["docker"],
       "matchPackagePatterns": ["/factory\\.talos\\.dev/"],
       "packageNameTemplate": "ghcr.io/siderolabs/installer"
+    },
+    {
+      "description": [
+        "Pin kubelet to <1.36.0 — Talos v1.12.x supports up to k8s 1.35.x.",
+        "Lift this constraint once Talos v1.13.x ships (which adds 1.36 support)."
+      ],
+      "matchPackageNames": ["ghcr.io/siderolabs/kubelet"],
+      "allowedVersions": "<1.36.0"
+    },
+    {
+      "description": [
+        "Don't auto-merge Talos installer bumps — minor-in-semver bumps still",
+        "trigger a rolling reboot of every node (mons/OSDs go briefly down).",
+        "Force manual review so upgrades land in a known maintenance window."
+      ],
+      "matchPackageNames": ["ghcr.io/siderolabs/installer"],
+      "automerge": false
     }
   ]
 }

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   kubernetes:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-    version: v1.36.0
+    version: v1.35.4

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -3,7 +3,7 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.12.7
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.36.0
+kubernetesVersion: v1.35.4
 
 clusterName: "valhalla"
 endpoint: https://192.168.1.101:6443


### PR DESCRIPTION
## Summary

Stop tuppr from looping on a Kubernetes upgrade Talos can't perform yet, and prevent the same thing happening again the next time renovate auto-merges a kubelet bump.

- Revert `kubernetesVersion` in `talconfig.yaml` and `kubernetesupgrade.yaml` back to **v1.35.4**
- Pin `ghcr.io/siderolabs/kubelet` to `<1.36.0` in renovate overrides
- Disable auto-merge for `ghcr.io/siderolabs/installer` (Talos)

## Background

Last night tuppr created upgrade jobs for Kubernetes v1.36.0 (after #1408 auto-merged) and they failed with:

```
unsupported upgrade path 1.35->1.36 (from "1.35.4" to "1.36.0")
```

Talos v1.12.x caps at k8s 1.35.x — confirmed by `DefaultKubernetesVersion = "1.35.4"` and `SupportedKubernetesVersions = 6` in `siderolabs/talos@v1.12.7/pkg/machinery/constants/constants.go`. Talos v1.13 is needed for k8s 1.36 support, and currently only **v1.13.0-rc.0** exists (released 2026-04-16). No stable v1.13 yet.

Separately, the same night #1416 auto-merged Talos installer 1.12.6 → 1.12.7 (minor-in-semver), which tuppr applied as a rolling reboot. This is what caused the `CephMonDown` / `CephOSDDown` / `CephOSDHostDown` alerts overnight — each node's mon and OSD went briefly down during its reboot. Functionally a successful upgrade, just very noisy because nothing waited for a maintenance window.

## How this prevents recurrence

- **Pinning kubelet to <1.36.0** keeps renovate from offering a kubelet major-cycle bump until we explicitly lift the pin. When Talos v1.13.x stable ships, drop this pin and let renovate proceed.
- **Disabling auto-merge for the installer** means future Talos bumps (minor or major) land as a PR for manual review. We can then merge during a planned window so the rolling reboot ceph noise is expected, not 03:00 surprise alerts.

## Test plan

- [ ] Once merged + reconciled, `kubectl -n system-upgrade get kubernetesupgrade kubernetes -o jsonpath='{.spec.kubernetes.version}'` returns `v1.35.4`
- [ ] No new failing upgrade jobs in `kubernetes-baldur-*`
- [ ] `KubernetesUpgrade` status transitions to a non-`Pending` phase (currentVersion == targetVersion)
- [ ] Next renovate run does not propose kubelet 1.36.x
- [ ] When Talos v1.13.x stable releases, renovate opens a PR but does not auto-merge it