### PR TITLE
feat(k8s)!: upgrade Kubernetes to v1.36.0

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -15,14 +15,6 @@
     },
     {
       "description": [
-        "Pin kubelet to <1.36.0 — Talos v1.12.x supports up to k8s 1.35.x.",
-        "Lift this constraint once Talos v1.13.x ships (which adds 1.36 support)."
-      ],
-      "matchPackageNames": ["ghcr.io/siderolabs/kubelet"],
-      "allowedVersions": "<1.36.0"
-    },
-    {
-      "description": [
         "Don't auto-merge Talos installer bumps — minor-in-semver bumps still",
         "trigger a rolling reboot of every node (mons/OSDs go briefly down).",
         "Force manual review so upgrades land in a known maintenance window."

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   kubernetes:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-    version: v1.35.4
+    version: v1.36.0

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -3,7 +3,7 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.13.0
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.35.4
+kubernetesVersion: v1.36.0
 
 clusterName: "valhalla"
 endpoint: https://192.168.1.101:6443


### PR DESCRIPTION
## Summary

Bump cluster Kubernetes v1.35.4 → v1.36.0 now that Talos v1.13.0 stable supports it.

- Lift the temporary `kubelet < 1.36.0` allowedVersions pin in `.renovate/overrides.json5`
- `kubernetesVersion: v1.36.0` in `talos/talconfig.yaml`
- `version: v1.36.0` in `tuppr/upgrades/kubernetesupgrade.yaml`

**Do not merge before #1428 (Talos v1.13.0) is fully rolled out.**

## Why now

Talos v1.13.0 GA shipped 2026-04-27. `pkg/machinery/constants/constants.go` shows `DefaultKubernetesVersion = "1.36.0"` with 6 versions back, so 1.36 is supported.

## Test plan

- [ ] All 3 nodes on Talos v1.13.0 before merge
- [ ] Tuppr rolls kubelet upgrade per node
- [ ] `kubectl get nodes` shows all nodes Ready on `v1.36.0`
- [ ] No `unsupported upgrade path` errors this time
- [ ] Ceph stays HEALTH_OK (kubelet bump does not reboot nodes, so no mon/OSD downtime expected)