### PR TITLE
chore(renovate): pin grafana-community Loki to <13

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -29,6 +29,15 @@
       ],
       "matchPackageNames": ["ghcr.io/grafana/helm-charts/loki"],
       "allowedVersions": "<7.0.0"
+    },
+    {
+      "description": [
+        "Pin grafana-community Loki to <13 — fork jumped 6.x → 13.x as part of",
+        "umbrella versioning across charts in the monorepo. Stay on 6.x until",
+        "we explicitly evaluate the 13.x line."
+      ],
+      "matchPackageNames": ["ghcr.io/grafana-community/helm-charts/loki"],
+      "allowedVersions": "<13.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Pin `ghcr.io/grafana-community/helm-charts/loki` to `<13.0.0` in renovate overrides.

## Why

The community fork rolled from 6.56.x straight to 13.3.x as part of an umbrella version scheme shared across the monorepo (sibling charts include `grafana-11.x`, `tempo-distributed-2.17.x`). It's not a regular Loki major — release notes are mostly CI/template work — but it's also not a casual minor bump worth merging without review.

Stay on the 6.x line until we explicitly evaluate the 13.x changes.

Closes #1418.

## Test plan

- [ ] Renovate next run does not re-create the 13.x bump PR
- [ ] Renovate continues to track 6.x patches if any get released