### PR TITLE
fix(victoria-metrics): drop unsupported scrapeInterval from VMSingle

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -37,7 +37,6 @@ spec:
       enabled: true
       spec:
         retentionPeriod: "14d"
-        scrapeInterval: 1m
         externalLabels:
           cluster: valhalla
         extraArgs:


### PR DESCRIPTION
VMSingle CRD does not have a scrapeInterval field. Caused the chart install to fail with a typed-patch schema error. Removing the bad field unblocks the rollout — vmagent (which actually scrapes) keeps its scrapeInterval setting.