### PR TITLE
fix(victoria-metrics): drop externalLabels from VMSingle spec

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -37,8 +37,6 @@ spec:
       enabled: true
       spec:
         retentionPeriod: "14d"
-        externalLabels:
-          cluster: valhalla
         extraArgs:
           maxLabelsPerTimeseries: "40"
         resources:


### PR DESCRIPTION
Same root cause as #1440. VMSingle CRD doesn't accept externalLabels — that field belongs on vmagent (already configured). Removing the redundant + invalid field unblocks the Helm install.