### PR TITLE
fix(observability): point consumers at correct vmsingle port (8428)

### DIFF
--- a/kubernetes/apps/observability/grafana-operator/instance/grafanadatasource.yaml
+++ b/kubernetes/apps/observability/grafana-operator/instance/grafanadatasource.yaml
@@ -15,7 +15,7 @@ spec:
     access: proxy
     isDefault: true
     # VictoriaMetrics single-node — PromQL-compatible drop-in
-    url: http://vmsingle-vm.observability.svc.cluster.local:8429
+    url: http://vmsingle-vm.observability.svc.cluster.local:8428
     jsonData:
       timeInterval: 1m
 ---

--- a/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kromgo/app/helmrelease.yaml
@@ -37,7 +37,7 @@ spec:
               repository: ghcr.io/kashalls/kromgo
               tag: v0.9.1
             env:
-              PROMETHEUS_URL: http://vmsingle-vm.observability.svc.cluster.local:8429
+              PROMETHEUS_URL: http://vmsingle-vm.observability.svc.cluster.local:8428
               SERVER_HOST: 0.0.0.0
               SERVER_PORT: &port 8080
               HEALTH_HOST: 0.0.0.0

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
         enabled: true
         urlPrefix: /
         ssl: false
-        prometheusEndpoint: http://vmsingle-vm.observability.svc.cluster.local:8429
+        prometheusEndpoint: http://vmsingle-vm.observability.svc.cluster.local:8428
       mgr:
         modules:
           - name: pg_autoscaler


### PR DESCRIPTION
Migration PR (#1438) set Grafana / kromgo / rook-ceph dashboard to query vmsingle on 8429, but that's vmagent's port. vmsingle's PromQL API is on 8428. Without this fix the consumers can't reach metrics — Grafana shows no data, kromgo badges go stale, ceph dashboard panels blank.