### PR TITLE
feat(victoria-metrics): expose UI routes via envoy gateway

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -35,6 +35,13 @@ spec:
 
     vmsingle:
       enabled: true
+      route:
+        enabled: true
+        hostnames: ["prometheus.${CLUSTER_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
       spec:
         retentionPeriod: "14d"
         extraArgs:
@@ -73,6 +80,13 @@ spec:
 
     vmalert:
       enabled: true
+      route:
+        enabled: true
+        hostnames: ["vmalert.${CLUSTER_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
       spec:
         evaluationInterval: 1m
         selectAllByDefault: true
@@ -89,6 +103,13 @@ spec:
 
     vmalertmanager:
       enabled: true
+      route:
+        enabled: true
+        hostnames: ["alertmanager.${CLUSTER_DOMAIN}"]
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
       # Inline alertmanager.yaml — avoids the chicken-and-egg of a separate
       # VMAlertmanagerConfig CRD that wouldn't exist until after this chart
       # had already failed to apply.


### PR DESCRIPTION
Restore the prometheus/alertmanager UI routes that the old kube-prometheus-stack shipped, plus a new one for vmalert. Hostnames preserved (prometheus.${CLUSTER_DOMAIN}, alertmanager.${CLUSTER_DOMAIN}) for bookmark compatibility — vmsingle's API is PromQL-compatible.