### PR TITLE
fix(victoria-metrics): expose UIs via raw HTTPRoute manifests

### DIFF
--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -35,13 +35,6 @@ spec:
 
     vmsingle:
       enabled: true
-      route:
-        enabled: true
-        hostnames: ["prometheus.${CLUSTER_DOMAIN}"]
-        parentRefs:
-          - name: envoy-internal
-            namespace: network
-            sectionName: https
       spec:
         retentionPeriod: "14d"
         extraArgs:
@@ -80,13 +73,6 @@ spec:
 
     vmalert:
       enabled: true
-      route:
-        enabled: true
-        hostnames: ["vmalert.${CLUSTER_DOMAIN}"]
-        parentRefs:
-          - name: envoy-internal
-            namespace: network
-            sectionName: https
       spec:
         evaluationInterval: 1m
         selectAllByDefault: true
@@ -103,13 +89,6 @@ spec:
 
     vmalertmanager:
       enabled: true
-      route:
-        enabled: true
-        hostnames: ["alertmanager.${CLUSTER_DOMAIN}"]
-        parentRefs:
-          - name: envoy-internal
-            namespace: network
-            sectionName: https
       # Inline alertmanager.yaml — avoids the chicken-and-egg of a separate
       # VMAlertmanagerConfig CRD that wouldn't exist until after this chart
       # had already failed to apply.

--- a/kubernetes/apps/observability/victoria-metrics/app/httproute.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/httproute.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vmsingle
+spec:
+  hostnames:
+    - prometheus.${CLUSTER_DOMAIN}
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: vmsingle-vm
+          port: 8428
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vmalertmanager
+spec:
+  hostnames:
+    - alertmanager.${CLUSTER_DOMAIN}
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: vmalertmanager-vm
+          port: 9093
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vmalert
+spec:
+  hostnames:
+    - vmalert.${CLUSTER_DOMAIN}
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: vmalert-vm
+          port: 8080

--- a/kubernetes/apps/observability/victoria-metrics/app/kustomization.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
   - ./alerts
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml
   - ./ocirepository.yaml
   - ./scrapeconfig.yaml


### PR DESCRIPTION
Chart 0.61.2's vmsingle.route helpers don't actually emit HTTPRoutes (added in a later version). Drop the dead blocks from helm values and create raw HTTPRoute manifests instead — matches the pattern used by other apps in this repo.