### PR TITLE
fix(victoria-logs): bump memory limit to 1.5Gi

### DIFF
--- a/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-logs/app/helmrelease.yaml
@@ -25,8 +25,8 @@ spec:
       resources:
         requests:
           cpu: 50m
-          memory: 128Mi
+          memory: 256Mi
         limits:
-          memory: 512Mi
+          memory: 1500Mi
       serviceMonitor:
         enabled: true


### PR DESCRIPTION
OOMKilled at 512Mi → CrashLoopBackOff → empty endpoints → 503 from envoy. Bumping to match vmsingle.