### PR TITLE
fix(observability): clear leftover scrape pool + target-down noise

### DIFF
--- a/kubernetes/apps/observability/grafana-operator/instance/servicemonitor.yaml
+++ b/kubernetes/apps/observability/grafana-operator/instance/servicemonitor.yaml
@@ -7,7 +7,9 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: grafana
+      # grafana-operator names its generated service `grafana-service`
+      # with this label set; matching the plain "grafana" name finds nothing.
+      grafana.internal/instance: grafana
   endpoints:
     - port: grafana
       interval: 1m

--- a/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/victoria-metrics/app/helmrelease.yaml
@@ -29,9 +29,15 @@ spec:
 
     defaultRules:
       create: true
-      rules:
-        kubeApiserverBurnrate: false
-        kubeApiserverSlos: false
+      # Disable rule groups that don't apply on Talos (kube-scheduler /
+      # kube-controller-manager metrics aren't reachable per default
+      # without extra config) or that produce noise without a payoff.
+      groups:
+        kubeApiserverBurnrate: { create: false }
+        kubeApiserverSlos: { create: false }
+        kubeScheduler: { create: false }
+        kubernetesSystemScheduler: { create: false }
+        kubernetesSystemControllerManager: { create: false }
 
     vmsingle:
       enabled: true
@@ -44,7 +50,7 @@ spec:
             cpu: 100m
             memory: 256Mi
           limits:
-            memory: 1Gi
+            memory: 2Gi
         storage:
           accessModes: ["ReadWriteOnce"]
           storageClassName: ceph-block
@@ -214,17 +220,15 @@ spec:
       enabled: true
     kubeApiServer:
       enabled: true
+    # kube-scheduler / kube-controller-manager are bound to localhost on
+    # Talos by default — scrape would always fail and trigger TargetDown
+    # noise. Same for kubeEtcd / kubeProxy on Talos.
     kubeControllerManager:
-      enabled: true
-      endpoints: &cp
-        - 192.168.1.105
-        - 192.168.1.106
-        - 192.168.1.107
+      enabled: false
     kubeEtcd:
       enabled: false
     kubeScheduler:
-      enabled: true
-      endpoints: *cp
+      enabled: false
     kubeProxy:
       enabled: false
 

--- a/kubernetes/apps/rook-ceph/rook-ceph/operator/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/operator/helmrelease.yaml
@@ -14,8 +14,11 @@ spec:
     csi:
       cephFSKernelMountOptions: ms_mode=prefer-crc
       enableLiveness: true
+      # csi-metrics service is not provisioned by this chart — enabling the
+      # ServiceMonitor produces an orphan VMServiceScrape with 0 targets,
+      # which triggers ScrapePoolHasNoTargets / TargetDown alerts.
       serviceMonitor:
-        enabled: true
+        enabled: false
     image:
       repository: ghcr.io/rook/ceph
     monitoring:


### PR DESCRIPTION
Cleanup pass after kpst→VictoriaMetrics migration. Six recurring alerts all root-caused to scrape configs pointing at nothing or rule groups depending on metrics we don't collect on Talos. See commit body for the four discrete changes.