### PR TITLE
fix(multus): re-enable automountServiceAccountToken (broken by app-template v5)

### DIFF
--- a/kubernetes/apps/network/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/network/multus/app/helmrelease.yaml
@@ -18,6 +18,10 @@ spec:
         pod:
           hostNetwork: true
           priorityClassName: system-node-critical
+          # app-template v5 defaults this to false; multus needs the SA token
+          # mounted at /var/run/secrets/kubernetes.io/serviceaccount/ to write
+          # its kubeconfig. Without it the container exits 0 in a restart loop.
+          automountServiceAccountToken: true
           tolerations:
             - key: CriticalAddonsOnly
               operator: Exists


### PR DESCRIPTION
app-template v5 flipped pod default automount→false. Multus needs the SA token to write its kubeconfig; without it the container exits 0 in a restart loop. Affects 2 of 3 nodes (the third still runs the pre-v5 pod).