### PR TITLE
feat(home-assistant): add code-server sidecar for in-pod editing

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
@@ -60,6 +60,32 @@ spec:
                 memory: 512Mi
               limits:
                 memory: 2Gi
+          code-server:
+            image:
+              repository: ghcr.io/coder/code-server
+              tag: 4.117.0@sha256:e6702766518b961c7e3c41095c129c7c9a82b041578c53326c52fa363a057727
+            args:
+              - --auth
+              - none
+              - --disable-telemetry
+              - --disable-update-check
+              - --user-data-dir
+              - /config/.vscode-server
+              - --extensions-dir
+              - /config/.vscode-server/extensions
+              - --port
+              - "12321"
+              - /config
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
 
     defaultPodOptions:
       securityContext:
@@ -75,7 +101,10 @@ spec:
         controller: home-assistant
         ports:
           http:
+            primary: true
             port: 8123
+          code-server:
+            port: 12321
 
     route:
       app:
@@ -89,6 +118,17 @@ spec:
           - backendRefs:
               - name: home-assistant
                 port: 8123
+      code:
+        hostnames:
+          - hass-code.${CLUSTER_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: home-assistant
+                port: 12321
 
     persistence:
       config:


### PR DESCRIPTION
## Summary

Adds a code-server sidecar to the Home Assistant pod, mirroring the existing zigbee2mqtt pattern. This is the **enabler** for moving HA config into git, à la `bjw-s/hass-config` — once code-server is reachable, you can \`git init\` inside \`/config\`, \`.gitignore\` the stateful bits, and start tracking the editable YAML in a private repo.

- Sidecar (not separate controller): HA's PVC is ceph-block / RWO, so multi-pod attach isn't possible. Same-pod sidecar shares the volume cleanly.
- Aparte hostname \`hass-code.${CLUSTER_DOMAIN}\` (envoy-internal, https section) instead of a path-prefix on \`hass.\` — HA uses many paths and a path-rewrite would be brittle.
- \`--auth none\`: envoy-internal already gates this; matches existing zigbee2mqtt/esphome convention.
- code-server data lives under \`/config/.vscode-server\` so it persists via the existing PVC and is trivial to \`.gitignore\` later.
- 8123 marked \`primary: true\` so the existing route stays unambiguous; 12321 added for code-server.

## Follow-up (manual, by the user)

After this lands and Flux reconciles, in code-server:

\`\`\`bash
cd /config
cat > .gitignore <<'GIT'
.storage/
*.db
*.db-shm
*.db-wal
secrets.yaml
ip_bans.yaml
tts/
backups/
.vscode-server/
*.log
*.log.*
GIT
git init
git remote add origin git@github.com:<you>/homelab-hass-config.git
git add .
git commit -m \"chore: initial import\"
git push -u origin main
\`\`\`

## Test plan

- [ ] Flux reconciles the HelmRelease without errors
- [ ] HA pod becomes Ready (both containers up: app + code-server)
- [ ] \`hass.altena.io\` keeps working (existing route unchanged)
- [ ] \`hass-code.altena.io\` serves the code-server UI
- [ ] code-server can read & write \`/config\` (try creating a file)
- [ ] No regression on Multus IoT VLAN attachment