### PR TITLE
fix(home-assistant): drop code-server securityContext (rootfs needs to be writable)

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
@@ -76,10 +76,6 @@ spec:
               - --port
               - "12321"
               - /config
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: { drop: ["ALL"] }
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
## Summary

Hotfix on top of #1473. The code-server sidecar I added had \`readOnlyRootFilesystem: true\`, which broke its startup:

\`\`\`
fixuid: fixuid is not running as root...
[error] ENOENT: no such file or directory, mkdir '/home/coder/.config'
\`\`\`

code-server's entrypoint runs \`fixuid\` to align UID/GID, which writes to \`/home/coder/.config\` before the \`--user-data-dir\` override is honored. That mkdir needs the rootfs writable.

Drop the per-container \`securityContext\` block so it falls back to \`defaultPodOptions\` (runAsNonRoot=true, runAsUser=1000, no read-only rootfs). This is how zigbee2mqtt and esphome already configure their code-server sidecars in this repo — consistent pattern.

Other security knobs unchanged: pod still runs as non-root UID 1000, seccomp=RuntimeDefault, fsGroup=1000.

## Test plan

- [ ] Pod becomes 2/2 Ready
- [ ] hass-code.altena.io serves the editor
- [ ] HA app container untouched