### PR TITLE
fix(home-assistant): restore baseline securityContext for code-server

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
@@ -76,6 +76,9 @@ spec:
               - --port
               - "12321"
               - /config
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
## Summary

Follow-up on #1474. That PR dropped the entire \`securityContext\` block to fix fixuid's mkdir on read-only rootfs — but it also dropped \`allowPrivilegeEscalation: false\` and \`capabilities.drop: [ALL]\`, which the cluster's restricted PodSecurity admission flags on every rollout:

\`\`\`
Warning: would violate PodSecurity \"restricted:latest\":
  allowPrivilegeEscalation != false (container \"code-server\" must set ...)
  unrestricted capabilities (container \"code-server\" must set capabilities.drop=[\"ALL\"])
\`\`\`

Re-add just those two knobs without \`readOnlyRootFilesystem\` — fixuid still works because the rootfs remains writable.

## Test plan

- [ ] Pod rolls out without PodSecurity warning
- [ ] code-server still starts (fixuid mkdir succeeds)
- [ ] hass-code.altena.io still serves the editor