### PR TITLE
fix(ceph): reduce clock skew alerts with stable NTP and relaxed drift tolerance

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -22,6 +22,7 @@ spec:
           bdev_enable_discard: "true"
           bdev_async_discard_threads: "1"
           osd_class_update_on_start: "false"
+          mon_clock_drift_allowed: "0.1"
       crashCollector:
         disable: false
       dashboard:

--- a/talos/patches/global/machine-time.yaml
+++ b/talos/patches/global/machine-time.yaml
@@ -3,6 +3,6 @@ machine:
   time:
     disabled: false
     servers:
-      - 0.europe.pool.ntp.org
-      - 1.europe.pool.ntp.org
-      - 2.europe.pool.ntp.org
+      - ntp.time.nl
+      - time.cloudflare.com
+      - time.google.com


### PR DESCRIPTION
## Summary
- Switch NTP servers from randomized `europe.pool.ntp.org` to dedicated anycast servers (`ntp.time.nl`, `time.cloudflare.com`, `time.google.com`) so all nodes sync against the same sources and minimize inter-node clock drift
- Increase Ceph `mon_clock_drift_allowed` from default 0.05s to 0.1s to prevent spurious `MON_CLOCK_SKEW` warnings

## Test plan
- [ ] Verify Flux reconciles the Ceph config change
- [ ] Monitor for absence of `MON_CLOCK_SKEW` alerts after next Talos config apply