### PR TITLE
fix(multus): move VLAN 20 from Talos to Multus DaemonSet

### DIFF
--- a/kubernetes/apps/network/multus/app/helmrelease.yaml
+++ b/kubernetes/apps/network/multus/app/helmrelease.yaml
@@ -31,6 +31,18 @@ spec:
             image:
               repository: ghcr.io/home-operations/cni-plugins
               tag: 1.9.1
+          vlan-setup:
+            image:
+              repository: ghcr.io/home-operations/cni-plugins
+              tag: 1.9.1
+            command: ["/bin/sh", "-c"]
+            args:
+              - |
+                ip link show enp1s0.20 >/dev/null 2>&1 || \
+                  ip link add link enp1s0 name enp1s0.20 type vlan id 20
+                ip link set enp1s0.20 up
+            securityContext:
+              privileged: true
 
         containers:
           multus:

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -39,9 +39,6 @@ nodes:
           - network: 0.0.0.0/0
             gateway: "192.168.1.1"
         mtu: 1500
-        vlans:
-          - vlanId: 20
-            dhcp: false
         vip:
           ip: "192.168.1.101"
   # Freya - Toshiba 256GB OS disk: naa.500080dc00d6459a
@@ -61,9 +58,6 @@ nodes:
           - network: 0.0.0.0/0
             gateway: "192.168.1.1"
         mtu: 1500
-        vlans:
-          - vlanId: 20
-            dhcp: false
         vip:
           ip: "192.168.1.101"
   # Heimdall - Toshiba 256GB OS disk: naa.500080dc00f48477
@@ -83,9 +77,6 @@ nodes:
           - network: 0.0.0.0/0
             gateway: "192.168.1.1"
         mtu: 1500
-        vlans:
-          - vlanId: 20
-            dhcp: false
         vip:
           ip: "192.168.1.101"
 


### PR DESCRIPTION
## Summary
- Remove VLAN 20 config from Talos `talconfig.yaml` on all 3 nodes
- Add `vlan-setup` init container to Multus DaemonSet that creates `enp1s0.20` on the host

Talos' `LinkSpecController` cascades VLAN creation onto macvlan sub-interfaces created by Multus, resulting in 7 spurious `.20` interfaces instead of 1, and continuous `error creating logical link: too many links` errors on all nodes.

## Test plan
- [ ] Verify Multus DaemonSet creates `enp1s0.20` on all nodes via init container
- [ ] Verify ESPHome and Home Assistant still have VLAN 20 connectivity (192.168.20.0/24)
- [ ] Verify `too many links` errors stop after `talosctl apply-config`
- [ ] Apply Talos config on all nodes to remove old VLAN interfaces