### PR TITLE
feat(ai): add LLM infrastructure with Hermes, LiteLLM and Toolhive MCP

### DIFF
--- a/kubernetes/apps/ai/hermes/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/hermes/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: hermes
+    creationPolicy: Owner
+    template:
+      data:
+        API_KEY: "{{ .api_key }}"
+  dataFrom:
+    - extract:
+        key: hermes

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -1,0 +1,201 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: hermes
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: hermes
+  interval: 30m
+  values:
+    controllers:
+      hermes:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        pod:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: "OnRootMismatch"
+
+        containers:
+          gateway:
+            image:
+              repository: nousresearch/hermes-agent
+              tag: v2026.5.16
+            args:
+              - gateway
+              - --config
+              - /etc/hermes/config.yaml
+            env:
+              API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: hermes
+                    key: API_KEY
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 5
+            resources:
+              requests:
+                cpu: 100m
+                memory: 2Gi
+              limits:
+                memory: 4Gi
+
+          dashboard:
+            image:
+              repository: nousresearch/hermes-agent
+              tag: v2026.5.16
+            args:
+              - dashboard
+              - --config
+              - /etc/hermes/config.yaml
+            env:
+              API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: hermes
+                    key: API_KEY
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+            resources:
+              requests:
+                cpu: 50m
+                memory: 1Gi
+              limits:
+                memory: 2Gi
+
+      codeserver:
+        containers:
+          app:
+            image:
+              repository: ghcr.io/coder/code-server
+              tag: 4.118.0
+            resources:
+              requests:
+                cpu: 10m
+                memory: 1Gi
+              limits:
+                memory: 2Gi
+
+    serviceAccount:
+      create: true
+      name: hermes
+
+    service:
+      gateway:
+        controller: hermes
+        ports:
+          http:
+            port: &gatewayPort 8642
+      dashboard:
+        controller: hermes
+        ports:
+          http:
+            port: &dashboardPort 9119
+      codeserver:
+        controller: codeserver
+        ports:
+          http:
+            port: &codeserverPort 12321
+
+    persistence:
+      config:
+        type: configMap
+        name: hermes-config
+        advancedMounts:
+          hermes:
+            gateway:
+              - path: /etc/hermes
+                readOnly: true
+            dashboard:
+              - path: /etc/hermes
+                readOnly: true
+      data:
+        existingClaim: hermes
+        advancedMounts:
+          hermes:
+            gateway:
+              - path: /opt/data
+            dashboard:
+              - path: /opt/data
+          codeserver:
+            app:
+              - path: /opt/data
+
+    route:
+      dashboard:
+        hostnames:
+          - hermes.${CLUSTER_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: dashboard
+                port: *dashboardPort
+      codeserver:
+        hostnames:
+          - hermes-code.${CLUSTER_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: codeserver
+                port: *codeserverPort
+
+    configMaps:
+      config:
+        data:
+          config.yaml: |
+            model:
+              default: haiku
+              provider: custom:kubernetes
+              base_url: http://litellm.ai.svc.cluster.local:4000/v1
+            fallback_providers:
+              - provider: custom:kubernetes
+                model: sonnet
+            providers:
+              kubernetes:
+                base_url: http://litellm.ai.svc.cluster.local:4000/v1
+            mcp_servers:
+              toolhive:
+                url: http://vmcp-mcp-gateway-internal.ai.svc.cluster.local:4483/mcp
+            toolsets:
+              - hermes-cli
+            terminal:
+              backend: local
+              cwd: /opt/data/workspace
+              persistent_shell: true
+            memory:
+              auto_migrate: true
+            compression:
+              enabled: true
+              threshold: 0.50
+              target_ratio: 0.20
+              protect_last_n: 20
+            agent:
+              max_turns: 90
+              gateway_timeout: 1800
+              reasoning_effort: medium
+            security:
+              redact_secrets: true
+

--- a/kubernetes/apps/ai/hermes/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./rbac.yaml

--- a/kubernetes/apps/ai/hermes/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/hermes/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: hermes
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/hermes/app/rbac.yaml
+++ b/kubernetes/apps/ai/hermes/app/rbac.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hermes-read-all
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - services
+      - configmaps
+      - events
+      - namespaces
+      - nodes
+      - persistentvolumes
+      - persistentvolumeclaims
+      - endpoints
+      - serviceaccounts
+      - resourcequotas
+      - limitranges
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
+      - csinodes
+      - csidrivers
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources:
+      - kustomizations
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources:
+      - helmreleases
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources:
+      - gitrepositories
+      - ocirepositories
+      - helmrepositories
+      - helmcharts
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+      - servicemonitors
+      - podmonitors
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["external-secrets.io"]
+    resources:
+      - externalsecrets
+      - clustersecretstores
+      - secretstores
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources:
+      - nodes
+      - pods
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hermes-read-all
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hermes-read-all
+subjects:
+  - kind: ServiceAccount
+    name: hermes
+    namespace: ai

--- a/kubernetes/apps/ai/hermes/ks.yaml
+++ b/kubernetes/apps/ai/hermes/ks.yaml
@@ -1,0 +1,37 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app hermes
+  namespace: flux-system
+spec:
+  targetNamespace: ai
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: external-secrets-stores
+    - name: litellm
+    - name: toolhive-config
+    - name: volsync
+    - name: rook-ceph-cluster
+  path: ./kubernetes/apps/ai/hermes/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      APP_UID: "1000"
+      APP_GID: "1000"
+      VOLSYNC_CAPACITY: 20Gi
+      VOLSYNC_STORAGECLASS: ceph-block
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool

--- a/kubernetes/apps/ai/kustomization.yaml
+++ b/kubernetes/apps/ai/kustomization.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./namespace.yaml
+  - ./litellm/ks.yaml
+  - ./toolhive/crds/ks.yaml
+  - ./toolhive/operator/ks.yaml
+  - ./toolhive/config/ks.yaml
+  - ./hermes/ks.yaml

--- a/kubernetes/apps/ai/litellm/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/litellm/app/externalsecret.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: litellm
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: litellm
+    creationPolicy: Owner
+    template:
+      data:
+        ANTHROPIC_API_KEY: "{{ .litellm_anthropic_api_key }}"
+        LITELLM_MASTER_KEY: "{{ .litellm_master_key }}"
+        DB_PASSWORD: "{{ .litellm_db_password }}"
+        DATABASE_URL: "postgresql://litellm:{{ .litellm_db_password }}@homelab-rw.databases.svc.cluster.local:5432/litellm"
+        # Postgres Init
+        INIT_POSTGRES_DBNAME: litellm
+        INIT_POSTGRES_HOST: homelab-rw.databases.svc.cluster.local
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+        INIT_POSTGRES_PASS: "{{ .litellm_db_password }}"
+        INIT_POSTGRES_USER: litellm
+  dataFrom:
+    - extract:
+        key: litellm
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "litellm_$1"
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/ai/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/litellm/app/helmrelease.yaml
@@ -1,0 +1,159 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: litellm
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: litellm
+  interval: 30m
+  values:
+    controllers:
+      litellm:
+        annotations:
+          reloader.stakater.com/auto: "true"
+
+        pod:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: "OnRootMismatch"
+
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/onedr0p/postgres-init
+              tag: 17.4
+              pullPolicy: IfNotPresent
+            envFrom:
+              - secretRef:
+                  name: litellm
+
+        containers:
+          app:
+            image:
+              repository: ghcr.io/berriai/litellm
+              tag: v1.83.14-stable
+            env:
+              LITELLM_MASTER_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm
+                    key: LITELLM_MASTER_KEY
+              ANTHROPIC_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm
+                    key: ANTHROPIC_API_KEY
+              DATABASE_URL:
+                valueFrom:
+                  secretKeyRef:
+                    name: litellm
+                    key: DATABASE_URL
+            args:
+              - --config
+              - /etc/litellm/config.yaml
+              - --port
+              - "4000"
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 5
+            resources:
+              requests:
+                cpu: 50m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+
+      redis:
+        containers:
+          redis:
+            image:
+              repository: ghcr.io/valkey-io/valkey
+              tag: 9.1.0
+            resources:
+              requests:
+                cpu: 5m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+
+    service:
+      app:
+        forceRename: litellm
+        primary: true
+        controller: litellm
+        ports:
+          http:
+            port: &port 4000
+      redis:
+        controller: redis
+        ports:
+          http:
+            port: 6379
+
+    persistence:
+      config:
+        type: configMap
+        name: litellm-config
+        advancedMounts:
+          litellm:
+            app:
+              - path: /etc/litellm
+                readOnly: true
+      data:
+        existingClaim: litellm
+        advancedMounts:
+          litellm:
+            app:
+              - path: /data
+
+    route:
+      app:
+        hostnames:
+          - litellm.${CLUSTER_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: *port
+
+    configMaps:
+      config:
+        data:
+          config.yaml: |
+            model_list:
+              - model_name: haiku
+                litellm_params:
+                  model: anthropic/claude-3-5-haiku-latest
+                  api_key: os.environ/ANTHROPIC_API_KEY
+              - model_name: sonnet
+                litellm_params:
+                  model: anthropic/claude-sonnet-4-20250514
+                  api_key: os.environ/ANTHROPIC_API_KEY
+
+            litellm_settings:
+              drop_params: true
+              cache: true
+              cache_params:
+                type: redis
+                host: litellm-redis.ai.svc.cluster.local
+                port: 6379
+              num_retries: 2
+
+            general_settings:
+              master_key: os.environ/LITELLM_MASTER_KEY
+              database_url: os.environ/DATABASE_URL

--- a/kubernetes/apps/ai/litellm/app/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/ai/litellm/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/litellm/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: litellm
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app litellm
+  namespace: flux-system
+spec:
+  targetNamespace: ai
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: external-secrets-stores
+    - name: cnpg-cluster
+    - name: volsync
+    - name: rook-ceph-cluster
+  path: ./kubernetes/apps/ai/litellm/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      APP_UID: "1000"
+      APP_GID: "1000"
+      VOLSYNC_CAPACITY: 5Gi
+      VOLSYNC_STORAGECLASS: ceph-block
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool

--- a/kubernetes/apps/ai/namespace.yaml
+++ b/kubernetes/apps/ai/namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ai
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    volsync.backube/privileged-movers: "true"

--- a/kubernetes/apps/ai/toolhive/config/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/externalsecret.yaml
@@ -1,0 +1,41 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: toolhive-github
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: toolhive-github
+    creationPolicy: Owner
+    template:
+      data:
+        GITHUB_PERSONAL_ACCESS_TOKEN: "{{ .GITHUB_PERSONAL_ACCESS_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: toolhive
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: toolhive-garmin
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: toolhive-garmin
+    creationPolicy: Owner
+    template:
+      data:
+        GARMIN_EMAIL: "{{ .GARMIN_EMAIL }}"
+        GARMIN_PASSWORD: "{{ .GARMIN_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: toolhive

--- a/kubernetes/apps/ai/toolhive/config/app/garmin-mcp.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/garmin-mcp.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: toolhive.stacklok.com/v1alpha1
+kind: MCPServer
+metadata:
+  name: garmin-connect-mcp
+spec:
+  image: docker.io/node:24-alpine
+  transport: stdio
+  command: ["npx", "@nicolasvegam/garmin-connect-mcp@1.1.1"]
+  secretRef:
+    name: toolhive-garmin

--- a/kubernetes/apps/ai/toolhive/config/app/github-mcp.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/github-mcp.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: toolhive.stacklok.com/v1alpha1
+kind: MCPServer
+metadata:
+  name: github-mcp
+spec:
+  image: ghcr.io/github/github-mcp-server
+  transport: stdio
+  secretRef:
+    name: toolhive-github

--- a/kubernetes/apps/ai/toolhive/config/app/kubectl-mcp.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/kubectl-mcp.yaml
@@ -1,0 +1,103 @@
+---
+apiVersion: toolhive.stacklok.com/v1alpha1
+kind: MCPServer
+metadata:
+  name: kubectl-mcp
+spec:
+  image: docker.io/rohitghumare64/kubectl-mcp-server:1.24.0
+  transport: streamable-http
+  serviceAccountName: kubectl-mcp-readonly
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubectl-mcp-readonly
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubectl-mcp-readonly
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - services
+      - configmaps
+      - events
+      - namespaces
+      - nodes
+      - persistentvolumes
+      - persistentvolumeclaims
+      - endpoints
+      - serviceaccounts
+      - resourcequotas
+      - limitranges
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+      - replicasets
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+      - networkpolicies
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
+      - csinodes
+      - csidrivers
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources:
+      - kustomizations
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources:
+      - helmreleases
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources:
+      - gitrepositories
+      - ocirepositories
+      - helmrepositories
+      - helmcharts
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+      - servicemonitors
+      - podmonitors
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["external-secrets.io"]
+    resources:
+      - externalsecrets
+      - clustersecretstores
+      - secretstores
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources:
+      - nodes
+      - pods
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubectl-mcp-readonly
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubectl-mcp-readonly
+subjects:
+  - kind: ServiceAccount
+    name: kubectl-mcp-readonly
+    namespace: ai

--- a/kubernetes/apps/ai/toolhive/config/app/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./kubectl-mcp.yaml
+  - ./github-mcp.yaml
+  - ./garmin-mcp.yaml
+  - ./memory-mcp.yaml
+  - ./mcpgroup.yaml
+  - ./virtualmcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/config/app/mcpgroup.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/mcpgroup.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: toolhive.stacklok.com/v1alpha1
+kind: MCPGroup
+metadata:
+  name: mcp-tools
+spec:
+  mcpServers:
+    - name: kubectl-mcp
+    - name: github-mcp
+    - name: garmin-connect-mcp
+    - name: memory-mcp

--- a/kubernetes/apps/ai/toolhive/config/app/memory-mcp.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/memory-mcp.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: toolhive.stacklok.com/v1alpha1
+kind: MCPServer
+metadata:
+  name: memory-mcp
+spec:
+  image: ghcr.io/bjw-s-labs/mcp-memory:2026.1.26
+  transport: stdio
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: memory-mcp
+      mountPath: /data
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: memory-mcp
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: ceph-block

--- a/kubernetes/apps/ai/toolhive/config/app/virtualmcpserver.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/virtualmcpserver.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: toolhive.stacklok.com/v1alpha1
+kind: VirtualMCPServer
+metadata:
+  name: mcp-gateway-internal
+spec:
+  mcpGroupRef:
+    name: mcp-tools
+  conflictResolution:
+    type: Prefix
+    prefix:
+      format: "{workload}_"
+  incomingAuth:
+    type: Anonymous
+  outgoingAuth:
+    type: Discovered

--- a/kubernetes/apps/ai/toolhive/config/ks.yaml
+++ b/kubernetes/apps/ai/toolhive/config/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app toolhive-config
+  namespace: flux-system
+spec:
+  targetNamespace: ai
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: toolhive-operator
+    - name: external-secrets-stores
+  path: ./kubernetes/apps/ai/toolhive/config/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ai/toolhive/crds/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/toolhive/crds/app/helmrelease.yaml
@@ -1,0 +1,11 @@
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: toolhive-crds
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: toolhive-crds
+  interval: 30m

--- a/kubernetes/apps/ai/toolhive/crds/app/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/crds/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/ai/toolhive/crds/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/toolhive/crds/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: toolhive-crds
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.28.0
+  url: oci://ghcr.io/stacklok/toolhive/charts/toolhive-crds

--- a/kubernetes/apps/ai/toolhive/crds/ks.yaml
+++ b/kubernetes/apps/ai/toolhive/crds/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app toolhive-crds
+  namespace: flux-system
+spec:
+  targetNamespace: ai
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/ai/toolhive/crds/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/apps/ai/toolhive/operator/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/toolhive/operator/app/helmrelease.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: toolhive-operator
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: toolhive-operator
+  interval: 30m
+  values:
+    resources:
+      requests:
+        cpu: 50m
+        memory: 256Mi
+      limits:
+        memory: 512Mi

--- a/kubernetes/apps/ai/toolhive/operator/app/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/operator/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/ai/toolhive/operator/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/toolhive/operator/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: toolhive-operator
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.28.0
+  url: oci://ghcr.io/stacklok/toolhive/charts/toolhive-operator

--- a/kubernetes/apps/ai/toolhive/operator/ks.yaml
+++ b/kubernetes/apps/ai/toolhive/operator/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app toolhive-operator
+  namespace: flux-system
+spec:
+  targetNamespace: ai
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: toolhive-crds
+  path: ./kubernetes/apps/ai/toolhive/operator/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## Summary
- Add `ai` namespace with full LLM agent infrastructure
- **LiteLLM**: Anthropic API proxy (Haiku default, Sonnet fallback) with Valkey cache sidecar and PostgreSQL backend
- **Toolhive**: CRDs → Operator → Config (kubectl, GitHub, Garmin Connect, memory MCP servers + vMCP gateway)
- **Hermes**: AI agent with gateway, dashboard and code-server containers, read-only cluster RBAC

## 1Password items required
| Item | Fields |
|------|--------|
| `litellm` | `anthropic_api_key`, `master_key`, `db_password` |
| `hermes` | `api_key` |
| `toolhive` | `GITHUB_PERSONAL_ACCESS_TOKEN`, `GARMIN_EMAIL`, `GARMIN_PASSWORD` |

## Test plan
- [ ] `flux get ks -n flux-system | grep -E 'litellm|toolhive|hermes'` — all reconciled
- [ ] `kubectl get pods -n ai` — all pods running
- [ ] LiteLLM health endpoint responds
- [ ] MCP servers ready: `kubectl get mcpservers -n ai`
- [ ] Hermes dashboard accessible at `hermes.${CLUSTER_DOMAIN}`