### PR TITLE
fix(ai): correct Toolhive Helm chart OCI URLs

### DIFF
--- a/kubernetes/apps/ai/toolhive/crds/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/toolhive/crds/app/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 0.28.0
-  url: oci://ghcr.io/stacklok/toolhive/charts/toolhive-crds
+  url: oci://ghcr.io/stacklok/toolhive/toolhive-operator-crds

--- a/kubernetes/apps/ai/toolhive/operator/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/toolhive/operator/app/ocirepository.yaml
@@ -11,4 +11,4 @@ spec:
     operation: copy
   ref:
     tag: 0.28.0
-  url: oci://ghcr.io/stacklok/toolhive/charts/toolhive-operator
+  url: oci://ghcr.io/stacklok/toolhive/toolhive-operator


### PR DESCRIPTION
## Summary
- Fix OCI registry paths for Toolhive CRDs and operator charts
- `charts/toolhive-crds` → `toolhive-operator-crds`
- `charts/toolhive-operator` → `toolhive-operator`