### PR TITLE
fix(ai): correct configMap names in persistence references

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -117,7 +117,7 @@ spec:
     persistence:
       config:
         type: configMap
-        name: hermes-config
+        name: hermes
         advancedMounts:
           hermes:
             gateway:

--- a/kubernetes/apps/ai/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/litellm/app/helmrelease.yaml
@@ -105,7 +105,7 @@ spec:
     persistence:
       config:
         type: configMap
-        name: litellm-config
+        name: litellm
         advancedMounts:
           litellm:
             app:


### PR DESCRIPTION
Fix litellm and hermes configMap persistence names to match app-template naming convention.