### PR TITLE
fix(ai): fix Hermes configmap name and rework MCP server configs

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -156,7 +156,7 @@ spec:
           - path: /opt/data
       configmap:
         type: configMap
-        name: hermes-config
+        name: hermes
         defaultMode: 0755
         globalMounts:
           - path: /tmp/config.yaml

--- a/kubernetes/apps/ai/toolhive/config/app/garmin-mcp.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/garmin-mcp.yaml
@@ -6,11 +6,39 @@ metadata:
 spec:
   image: docker.io/node:24-alpine
   transport: stdio
-  args: ["npx", "@nicolasvegam/garmin-connect-mcp@1.1.1"]
-  groupRef:
-    name: mcp-tools
+  proxyMode: streamable-http
+  proxyPort: 8080
+  env:
+    - name: HOME
+      value: /tmp
+    - name: NPM_CONFIG_CACHE
+      value: /tmp/.npm
   secrets:
     - name: toolhive-garmin-email
       key: GARMIN_EMAIL
     - name: toolhive-garmin-password
       key: GARMIN_PASSWORD
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          image: docker.io/node:24-alpine
+          command:
+            - npx
+          args:
+            - -y
+            - "@nicolasvegam/garmin-connect-mcp@1.1.1"
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/config/app/github-mcp.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/github-mcp.yaml
@@ -6,8 +6,21 @@ metadata:
 spec:
   image: ghcr.io/github/github-mcp-server
   transport: stdio
-  groupRef:
-    name: mcp-tools
+  proxyMode: streamable-http
+  proxyPort: 8080
+  env:
+    - name: GITHUB_API_URL
+      value: https://api.github.com
+    - name: LOG_LEVEL
+      value: info
   secrets:
     - name: toolhive-github
       key: GITHUB_PERSONAL_ACCESS_TOKEN
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/config/app/kubectl-mcp.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/kubectl-mcp.yaml
@@ -6,7 +6,33 @@ metadata:
 spec:
   image: docker.io/rohitghumare64/kubectl-mcp-server:1.24.0
   transport: streamable-http
+  proxyMode: streamable-http
+  proxyPort: 8080
+  mcpPort: 8000
   serviceAccount: kubectl-mcp-readonly
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      memory: 512Mi
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          args:
+            - --transport
+            - streamable-http
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8000"
+            - --read-only
+          env:
+            - name: MCP_K8S_PROVIDER
+              value: in-cluster
+            - name: PYTHONUNBUFFERED
+              value: "1"
   groupRef:
     name: mcp-tools
 ---
@@ -23,6 +49,7 @@ rules:
   - apiGroups: [""]
     resources:
       - pods
+      - pods/log
       - services
       - configmaps
       - events


### PR DESCRIPTION
## Summary
- Fix Hermes configmap reference from `hermes-config` to `hermes` (matching app-template generated name)
- Rework kubectl-mcp: add `proxyMode`, `proxyPort`, `mcpPort`, `podTemplateSpec` with streamable-http args
- Rework garmin-mcp: add `HOME=/tmp`, `NPM_CONFIG_CACHE=/tmp/.npm`, emptyDir tmp volume via `podTemplateSpec`
- Rework github-mcp: add `proxyMode`, `proxyPort`, env vars, resources

## Test plan
- [ ] Hermes init container starts (configmap mounts successfully)
- [ ] kubectl-mcp StatefulSet pod starts and stays running
- [ ] garmin-mcp npm install succeeds with writable HOME
- [ ] github-mcp continues to run
- [ ] vMCP gateway shows all backends as Ready