### PR TITLE
fix(ai): add Discord bot_token and allowed_users to Hermes configs

### DIFF
--- a/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
@@ -264,6 +264,8 @@ spec:
               toolhive:
                 url: http://vmcp-mcp-gateway-internal.ai.svc.cluster.local:4483/mcp
             discord:
+              bot_token: $${DISCORD_BOT_TOKEN}
+              allowed_users: $${DISCORD_ALLOWED_USERS}
               require_mention: true
               auto_thread: true
               reactions: true

--- a/kubernetes/apps/ai/hermes-marja/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-marja/app/helmrelease.yaml
@@ -264,6 +264,8 @@ spec:
               toolhive:
                 url: http://vmcp-mcp-gateway-internal.ai.svc.cluster.local:4483/mcp
             discord:
+              bot_token: $${DISCORD_BOT_TOKEN}
+              allowed_users: $${DISCORD_ALLOWED_USERS}
               require_mention: true
               auto_thread: true
               reactions: true


### PR DESCRIPTION
## Summary
- Add `bot_token` and `allowed_users` to discord config section for both Inframan and Marja
- Gateway wasn't connecting to Discord because the token was only in env vars but not referenced in config.yaml