### PR TITLE
feat(ai): switch Hermes bots to OpenAI via LiteLLM

### DIFF
--- a/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
@@ -249,13 +249,13 @@ spec:
         data:
           config.yaml: |
             model:
-              default: haiku
+              default: gpt-4.1-mini
               provider: custom:kubernetes
               base_url: http://litellm.ai.svc.cluster.local:4000/v1
               api_key: $${LITELLM_API_KEY}
             fallback_providers:
               - provider: custom:kubernetes
-                model: sonnet
+                model: gpt-4.1
             providers:
               kubernetes:
                 base_url: http://litellm.ai.svc.cluster.local:4000/v1

--- a/kubernetes/apps/ai/hermes-marja/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-marja/app/helmrelease.yaml
@@ -249,13 +249,13 @@ spec:
         data:
           config.yaml: |
             model:
-              default: haiku
+              default: gpt-4.1-mini
               provider: custom:kubernetes
               base_url: http://litellm.ai.svc.cluster.local:4000/v1
               api_key: $${LITELLM_API_KEY}
             fallback_providers:
               - provider: custom:kubernetes
-                model: sonnet
+                model: gpt-4.1
             providers:
               kubernetes:
                 base_url: http://litellm.ai.svc.cluster.local:4000/v1

--- a/kubernetes/apps/ai/litellm/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/litellm/app/externalsecret.yaml
@@ -15,6 +15,7 @@ spec:
     template:
       data:
         ANTHROPIC_API_KEY: "{{ .litellm_anthropic_api_key }}"
+        OPENAI_API_KEY: "{{ .litellm_openai_api_key }}"
         LITELLM_MASTER_KEY: "{{ .litellm_master_key }}"
         DB_PASSWORD: "{{ .litellm_db_password }}"
         DATABASE_URL: "postgresql://litellm:{{ .litellm_db_password }}@homelab-rw.databases.svc.cluster.local:5432/litellm"

--- a/kubernetes/apps/ai/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/litellm/app/helmrelease.yaml
@@ -147,6 +147,14 @@ spec:
                 litellm_params:
                   model: anthropic/claude-sonnet-4-20250514
                   api_key: os.environ/ANTHROPIC_API_KEY
+              - model_name: gpt-4.1-mini
+                litellm_params:
+                  model: openai/gpt-4.1-mini
+                  api_key: os.environ/OPENAI_API_KEY
+              - model_name: gpt-4.1
+                litellm_params:
+                  model: openai/gpt-4.1
+                  api_key: os.environ/OPENAI_API_KEY
 
             general_settings:
               health_check_endpoint: /v1/health


### PR DESCRIPTION
## Summary
- Add gpt-4.1-mini and gpt-4.1 models to LiteLLM config
- Switch both Inframan and Marja default model from haiku to gpt-4.1-mini
- Switch fallback from sonnet to gpt-4.1
- Add OPENAI_API_KEY to LiteLLM ExternalSecret

## 1Password
Add `openai_api_key` field to the `litellm` 1Password item.

## Why
Anthropic basic tier rate limit (30k input tokens/min) is too low for two Discord bots with large system prompts.