### PR TITLE
fix(ai): remove Anthropic from LiteLLM, use OpenAI only

### DIFF
--- a/kubernetes/apps/ai/litellm/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/litellm/app/externalsecret.yaml
@@ -14,7 +14,7 @@ spec:
     creationPolicy: Owner
     template:
       data:
-        ANTHROPIC_API_KEY: "{{ .litellm_anthropic_api_key }}"
+        OPENAI_API_KEY: "{{ .litellm_openai_api_key }}"
         LITELLM_MASTER_KEY: "{{ .litellm_master_key }}"
         DB_PASSWORD: "{{ .litellm_db_password }}"
         DATABASE_URL: "postgresql://litellm:{{ .litellm_db_password }}@homelab-rw.databases.svc.cluster.local:5432/litellm"

--- a/kubernetes/apps/ai/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/litellm/app/helmrelease.yaml
@@ -139,14 +139,14 @@ spec:
         data:
           config.yaml: |
             model_list:
-              - model_name: haiku
+              - model_name: gpt-4.1-mini
                 litellm_params:
-                  model: anthropic/claude-3-5-haiku-latest
-                  api_key: os.environ/ANTHROPIC_API_KEY
-              - model_name: sonnet
+                  model: openai/gpt-4.1-mini
+                  api_key: os.environ/OPENAI_API_KEY
+              - model_name: gpt-4.1
                 litellm_params:
-                  model: anthropic/claude-sonnet-4-20250514
-                  api_key: os.environ/ANTHROPIC_API_KEY
+                  model: openai/gpt-4.1
+                  api_key: os.environ/OPENAI_API_KEY
 
             general_settings:
               health_check_endpoint: /v1/health


### PR DESCRIPTION
## Summary
- Remove ANTHROPIC_API_KEY from LiteLLM ExternalSecret (key was deleted from 1Password)
- Replace Anthropic models (haiku, sonnet) with OpenAI models (gpt-4.1-mini, gpt-4.1)
- Fixes ExternalSecret sync failure: `map has no entry for key "litellm_anthropic_api_key"`