### PR TITLE
feat(ai): add MiniMax M2.7 as default model for Hermes bots

### DIFF
--- a/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
@@ -249,13 +249,13 @@ spec:
         data:
           config.yaml: |
             model:
-              default: gpt-4.1-mini
+              default: minimax
               provider: custom:kubernetes
               base_url: http://litellm.ai.svc.cluster.local:4000/v1
               api_key: $${LITELLM_API_KEY}
             fallback_providers:
               - provider: custom:kubernetes
-                model: gpt-4.1
+                model: gpt-4.1-mini
             providers:
               kubernetes:
                 base_url: http://litellm.ai.svc.cluster.local:4000/v1

--- a/kubernetes/apps/ai/hermes-marja/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-marja/app/helmrelease.yaml
@@ -249,13 +249,13 @@ spec:
         data:
           config.yaml: |
             model:
-              default: gpt-4.1-mini
+              default: minimax
               provider: custom:kubernetes
               base_url: http://litellm.ai.svc.cluster.local:4000/v1
               api_key: $${LITELLM_API_KEY}
             fallback_providers:
               - provider: custom:kubernetes
-                model: gpt-4.1
+                model: gpt-4.1-mini
             providers:
               kubernetes:
                 base_url: http://litellm.ai.svc.cluster.local:4000/v1

--- a/kubernetes/apps/ai/litellm/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/litellm/app/externalsecret.yaml
@@ -14,6 +14,7 @@ spec:
     creationPolicy: Owner
     template:
       data:
+        MINIMAX_API_KEY: "{{ .litellm_minimax_api_key }}"
         OPENAI_API_KEY: "{{ .litellm_openai_api_key }}"
         LITELLM_MASTER_KEY: "{{ .litellm_master_key }}"
         DB_PASSWORD: "{{ .litellm_db_password }}"

--- a/kubernetes/apps/ai/litellm/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/litellm/app/helmrelease.yaml
@@ -139,6 +139,17 @@ spec:
         data:
           config.yaml: |
             model_list:
+              - model_name: minimax
+                model_info:
+                  mode: chat
+                  max_input_tokens: 204800
+                  max_output_tokens: 131072
+                  supports_function_calling: true
+                litellm_params:
+                  model: minimax/MiniMax-M2.7
+                  api_base: https://api.minimax.io/v1
+                  api_key: os.environ/MINIMAX_API_KEY
+                  drop_params: true
               - model_name: gpt-4.1-mini
                 litellm_params:
                   model: openai/gpt-4.1-mini


### PR DESCRIPTION
## Summary
- Add MiniMax-M2.7 to LiteLLM as default model for both Hermes bots
- MiniMax has no tool count limit (OpenAI caps at 128, Hermes sends 441 tools)
- OpenAI gpt-4.1-mini kept as fallback
- Add MINIMAX_API_KEY to LiteLLM ExternalSecret

## 1Password
Add `minimax_api_key` field to the `litellm` 1Password item.