### PR TITLE
fix(volsync): increase KopiaMaintenance cache capacity to 10Gi

### DIFF
--- a/kubernetes/apps/volsync-system/kopia/app/kopiamaintenance.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/kopiamaintenance.yaml
@@ -18,6 +18,9 @@ spec:
   trigger:
     schedule: "30 3,15 * * *"
   cacheStorageClassName: ceph-block
+  cacheCapacity: 10Gi
+  metadataCacheSizeLimitMB: 4096
+  contentCacheSizeLimitMB: 4096
   podSecurityContext:
     fsGroup: 1000
     runAsGroup: 1000


### PR DESCRIPTION
## Summary

- Increases `cacheCapacity` from default 1Gi to 10Gi for the KopiaMaintenance resource
- Sets `metadataCacheSizeLimitMB: 4096` and `contentCacheSizeLimitMB: 4096`

## Why

During the first maintenance run (with 65k+ index blobs accumulated), kopia exhausted the default 1Gi cache PVC with `no space left on device`. After maintenance compacts the blobs, subsequent runs won't need as much space, but the initial run requires room to load all 65k+ index blobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)