### PR TITLE
fix(ai): trim tools per bot — remove bundled skills, split MCP servers

### DIFF
--- a/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
@@ -261,8 +261,10 @@ spec:
                 base_url: http://litellm.ai.svc.cluster.local:4000/v1
                 api_key: $${LITELLM_API_KEY}
             mcp_servers:
-              toolhive:
-                url: http://vmcp-mcp-gateway-internal.ai.svc.cluster.local:4483/mcp
+              kubectl:
+                url: http://mcp-kubectl-mcp-proxy.ai.svc.cluster.local:8080/mcp
+              github:
+                url: http://mcp-github-mcp-proxy.ai.svc.cluster.local:8080/mcp
             discord:
               bot_token: $${DISCORD_BOT_TOKEN}
               allowed_users: $${DISCORD_ALLOWED_USERS}
@@ -270,12 +272,6 @@ spec:
               auto_thread: true
               reactions: true
               thread_require_mention: true
-            toolsets:
-              - hermes-cli
-            terminal:
-              backend: local
-              cwd: /opt/data/workspace
-              persistent_shell: true
             memory:
               auto_migrate: true
             compression:

--- a/kubernetes/apps/ai/hermes-marja/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-marja/app/helmrelease.yaml
@@ -261,8 +261,8 @@ spec:
                 base_url: http://litellm.ai.svc.cluster.local:4000/v1
                 api_key: $${LITELLM_API_KEY}
             mcp_servers:
-              toolhive:
-                url: http://vmcp-mcp-gateway-internal.ai.svc.cluster.local:4483/mcp
+              garmin:
+                url: http://mcp-garmin-connect-mcp-proxy.ai.svc.cluster.local:8080/mcp
             discord:
               bot_token: $${DISCORD_BOT_TOKEN}
               allowed_users: $${DISCORD_ALLOWED_USERS}
@@ -270,12 +270,6 @@ spec:
               auto_thread: true
               reactions: true
               thread_require_mention: true
-            toolsets:
-              - hermes-cli
-            terminal:
-              backend: local
-              cwd: /opt/data/workspace
-              persistent_shell: true
             memory:
               auto_migrate: true
             compression:


### PR DESCRIPTION
## Summary
- Remove `toolsets: [hermes-cli]` and `terminal` config from both bots (87 bundled skills gone)
- Marja: only garmin MCP server (was: all 3 via vMCP gateway)
- Inframan: only kubectl + github MCP servers (was: all 3 via vMCP gateway)
- Reduces tool count from 441 to only relevant tools per bot
- Fixes context window bloat causing early compression after ~15 min