### PR TITLE
fix(talos): increase vm.max_map_count to 262144

### DIFF
--- a/talos/patches/global/machine-sysctl.yaml
+++ b/talos/patches/global/machine-sysctl.yaml
@@ -6,3 +6,4 @@ machine:
     fs.inotify.max_user_instances: "8192"
     net.core.rmem_max: "2500000"
     net.core.wmem_max: "2500000"
+    vm.max_map_count: "262144"


### PR DESCRIPTION
## Summary

- Adds `vm.max_map_count: "262144"` to the global Talos sysctl patch

## Why

The default kernel value is 65530. With 65k+ kopia index blobs in the repository, kopia v0.22.3 (bundled in perfectra1n/volsync) hits this limit during repository connect, causing `mmap error: cannot allocate memory`. This blocks the `KopiaMaintenance` CronJob from running.

262144 is the standard recommendation for memory-mapped workloads (Elasticsearch, kopia, etc.) and gives plenty of headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)