### PR TITLE
fix(kopia): increase memory limit to 4Gi and add liveness probe delay

### DIFF
--- a/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
+++ b/kubernetes/apps/volsync-system/kopia/app/helmrelease.yaml
@@ -56,7 +56,7 @@ spec:
                   httpGet:
                     path: /
                     port: *port
-                  initialDelaySeconds: 0
+                  initialDelaySeconds: 30
                   periodSeconds: 30
                   timeoutSeconds: 1
                   failureThreshold: 3
@@ -66,7 +66,7 @@ spec:
                 cpu: 15m
                 memory: 128Mi
               limits:
-                memory: 1Gi
+                memory: 4Gi
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary

- Increases kopia memory limit from 1Gi to 4Gi
- Sets `initialDelaySeconds: 30` on liveness/readiness probes (was 0)

## Why

The kopia pod was stuck in CrashLoopBackOff due to two issues:
1. **OOMKill** when loading 65k+ kopia index blobs from NFS into memory
2. **Liveness probe failure** when NFS was slow at startup — with `initialDelaySeconds: 0` the probe fired immediately, before the kopia server had time to connect to the repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)