### PR TITLE
fix(ceph): require low current free space for CephNodeDiskspaceWarning

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -10,6 +10,16 @@ spec:
     name: rook-ceph-cluster
   interval: 30m
   timeout: 15m
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: PrometheusRule
+              name: prometheus-ceph-rules
+            patch: |-
+              - op: replace
+                path: /spec/groups/6/rules/4/expr
+                value: '(predict_linear(node_filesystem_free_bytes{device=~"/.*"}[2d], 3600 * 24 * 5) *on(instance) group_left(nodename) node_uname_info < 0) and on(device, instance, mountpoint) (node_filesystem_avail_bytes{device=~"/.*"} / node_filesystem_size_bytes{device=~"/.*"} < 0.25)'
   values:
     monitoring:
       enabled: true


### PR DESCRIPTION
## Summary

- Patches the `CephNodeDiskspaceWarning` PrometheusRule via a Flux `postRenderers` JSON6902 patch on the `rook-ceph-cluster` HelmRelease
- Adds an `and on(device, instance, mountpoint) (...avail / ...size < 0.25)` condition to the alert expression
- Alert now only fires when **both** the 2-day fill rate trend predicts filling in <5 days **and** current free space is actually below 25%

## Root cause

After any cluster operation that replaces node-exporter pods (node reboots, Talos config applies, DaemonSet rollouts), stale metrics from the old pods remain in VictoriaMetrics within the 2-day `predict_linear` window. If the old pod ran during maintenance chaos (crash loops, VolSync failures, container churn), its data shows a steep fill rate. The prediction extrapolates this into a false "filling in 5 days" warning even with 70–78% free space.

## Test plan

- [ ] Flux reconciles the HelmRelease and patches the PrometheusRule expr
- [ ] Current alert resolves (nodes have 70–78% free, well above the 25% threshold)
- [ ] Alert still fires correctly if `/var` genuinely drops below 25% free

🤖 Generated with [Claude Code](https://claude.com/claude-code)