### PR TITLE
fix(hermes): remove runAsUser/runAsGroup to allow s6-overlay to initialize as root

### DIFF
--- a/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
@@ -12,8 +12,6 @@ spec:
   values:
     defaultPodOptions:
       securityContext:
-        runAsUser: 10000
-        runAsGroup: 10000
         fsGroup: 10000
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile: { type: RuntimeDefault }
@@ -59,12 +57,6 @@ spec:
               - containerPort: &port 8642
                 name: http
                 protocol: TCP
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: false
-              capabilities:
-                add: ["CHOWN"]
-                drop: ["ALL"]
 
           dashboard:
             image: *image

--- a/kubernetes/apps/ai/hermes-marja/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-marja/app/helmrelease.yaml
@@ -12,8 +12,6 @@ spec:
   values:
     defaultPodOptions:
       securityContext:
-        runAsUser: 10000
-        runAsGroup: 10000
         fsGroup: 10000
         fsGroupChangePolicy: OnRootMismatch
         seccompProfile: { type: RuntimeDefault }
@@ -59,12 +57,6 @@ spec:
               - containerPort: &port 8642
                 name: http
                 protocol: TCP
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: false
-              capabilities:
-                add: ["CHOWN"]
-                drop: ["ALL"]
 
           dashboard:
             image: *image

--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -10,6 +10,16 @@ spec:
     name: rook-ceph-cluster
   interval: 30m
   timeout: 15m
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              kind: PrometheusRule
+              name: prometheus-ceph-rules
+            patch: |-
+              - op: replace
+                path: /spec/groups/6/rules/4/expr
+                value: '(predict_linear(node_filesystem_free_bytes{device=~"/.*"}[2d], 3600 * 24 * 5) *on(instance) group_left(nodename) node_uname_info < 0) and on(device, instance, mountpoint) (node_filesystem_avail_bytes{device=~"/.*"} / node_filesystem_size_bytes{device=~"/.*"} < 0.25)'
   values:
     monitoring:
       enabled: true


### PR DESCRIPTION
## Summary

- Remove `runAsUser: 10000` and `runAsGroup: 10000` from `defaultPodOptions.securityContext` for both Hermes bots
- Remove container-level `securityContext` overrides (capabilities, allowPrivilegeEscalation, readOnlyRootFilesystem)

The `hermes-agent` image uses `s6-overlay` as init system, which requires starting as root to initialize `/run` and then switches to uid 10000 internally. Setting `runAsUser: 10000` at pod level prevented this, causing a `CrashLoopBackOff` for 3+ days.

Fix based on [JoryIrving/home-ops](https://github.com/joryirving/home-ops) configuration.

## Test plan
- [ ] `hermes-inframan` pod reaches `Running` state
- [ ] `hermes-marja` pod reaches `Running` state
- [ ] Bots come online in Discord