### PR TITLE
feat(rook-ceph): add ceph-csi-drivers chart for 1.20.0 CSI RBAC (fixes broken CSI)

### DIFF
--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/helmrelease.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ceph-csi-drivers
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: ceph-csi-drivers
+  interval: 1h
+  # rook-ceph 1.20.0 ships ceph-csi-operator 1.0.1 but no longer renders the
+  # per-driver ServiceAccounts/RBAC. This chart supplies them (rook/rook#17644).
+  values:
+    drivers:
+      rbd:
+        enabled: true
+        name: rook-ceph.rbd.csi.ceph.com
+      cephfs:
+        enabled: true
+        name: rook-ceph.cephfs.csi.ceph.com
+        # preserved from the old rook-ceph csi.cephFSKernelMountOptions setting
+        kernelMountOptions: ms_mode=prefer-crc
+      nfs:
+        enabled: false
+      nvmeof:
+        enabled: false

--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/kustomization.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./rook-ceph/ks.yaml
-  - ./ceph-csi-drivers/ks.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/ocirepository.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: ceph-csi-drivers
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.0.1
+  url: oci://ghcr.io/home-operations/charts-mirror/ceph-csi-drivers

--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/ks.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ceph-csi-drivers
+  namespace: flux-system
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: rook-ceph
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: ceph-csi-drivers
+      namespace: rook-ceph
+  interval: 1h
+  path: ./kubernetes/apps/rook-ceph/ceph-csi-drivers/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: rook-ceph
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/ks.yaml
@@ -37,6 +37,7 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: rook-ceph
+    - name: ceph-csi-drivers
     - name: volsync
       namespace: flux-system
   healthChecks:


### PR DESCRIPTION
## Probleem
rook-ceph **1.20.0** (auto-gemerged via #1611) bundelt ceph-csi-operator **1.0.1**, die de per-driver ServiceAccounts/RBAC niet meer rendert. Gevolg: `*-ctrlplugin` Deployments starten niet (`serviceaccount "rbd-ctrlplugin-sa" not found`) → **CSI attach/provision cluster-breed kapot**. Upstream-regressie: [rook/rook#17644](https://github.com/rook/rook/issues/17644).

Flux bleef groen (helm upgrade slaagde), dus niets alerteerde — verergerd doordat `KubeDeploymentReplicasMismatch` wegviel bij de VictoriaMetrics-migratie (#1438).

## Fix
De officiële `ceph-csi-drivers` chart (1.0.1, = de meegeleverde operator-versie) als losse HelmRelease, die de SA's/RBAC + Driver CR's levert. Aanpak gebaseerd op [buroa/k8s-gitops@f9c7f3f](https://github.com/buroa/k8s-gitops/commit/f9c7f3f284164a86cfa0ff3d645cd139981e430e).

- **rbd + cephfs** aan (cephfs in gebruik door esphome); nfs/nvmeof uit
- `rook-ceph-cluster` `dependsOn: ceph-csi-drivers`

## ⚠️ Cutover (live cluster)
Mergen vereist een eenmalige adoption-stap: de bestaande RBAC (live workaround) + rook-owned Driver CR's moeten door Helm geadopteerd worden i.p.v. botsen. Wordt gemonitord uitgevoerd bij merge.

## Follow-up
- Renovate guard: rook `<1.20.x` tot #17644 opgelost is
- `KubeDeploymentReplicasMismatch` als VMRule terugzetten