### PR TITLE
fix(rook-ceph): cephfs kernelMountOptions must be a map

### DIFF
--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/helmrelease.yaml
@@ -20,7 +20,9 @@ spec:
         enabled: true
         name: rook-ceph.cephfs.csi.ceph.com
         # preserved from the old rook-ceph csi.cephFSKernelMountOptions setting
-        kernelMountOptions: ms_mode=prefer-crc
+        # (Driver CR expects a map, not a string)
+        kernelMountOptions:
+          ms_mode: prefer-crc
       nfs:
         enabled: false
       nvmeof:


### PR DESCRIPTION
Follow-up op #1612: `kernelMountOptions` in de Driver CR is map[string]string, niet een string — blokkeerde de helm install van ceph-csi-drivers.