### PR TITLE
fix(rook-ceph): make CephPoolGrowthWarning VM-compatible (dedup mgr series)

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -20,6 +20,21 @@ spec:
               - op: replace
                 path: /spec/groups/6/rules/4/expr
                 value: '(predict_linear(node_filesystem_free_bytes{device=~"/.*"}[2d], 3600 * 24 * 5) *on(instance) group_left(nodename) node_uname_info < 0) and on(device, instance, mountpoint) (node_filesystem_avail_bytes{device=~"/.*"} / node_filesystem_size_bytes{device=~"/.*"} < 0.25)'
+          # CephPoolGrowthWarning: a mgr pod restart (upgrade/failover) leaves the old
+          # pod's ceph_pool_percent_used series in the [2d] window, so the join hits
+          # "duplicate time series on the left side of group_right" and the rule errors
+          # for ~2 days (cascading into AlertingRulesError/RequestErrorsToAPI/TooManyLogs).
+          # `max by(...)` collapses the duplicate series. test op guards the index.
+          - target:
+              kind: PrometheusRule
+              name: prometheus-ceph-rules
+            patch: |-
+              - op: test
+                path: /spec/groups/7/rules/0/alert
+                value: CephPoolGrowthWarning
+              - op: replace
+                path: /spec/groups/7/rules/0/expr
+                value: '(max by (cluster,pool_id,instance) (predict_linear(ceph_pool_percent_used[2d], 3600 * 24 * 5)) * on(cluster,pool_id,instance) group_right() ceph_pool_metadata) >= 95'
   values:
     monitoring:
       enabled: true


### PR DESCRIPTION
## Probleem
Op VictoriaMetrics faalt de upstream ceph-regel `CephPoolGrowthWarning` met HTTP 422 (`duplicate time series on the left side of group_right`) na elke mgr-pod-herstart: de oude pod's `ceph_pool_percent_used`-series blijven in het `[2d]`-venster van `predict_linear` hangen. De regel faalt dan ~2 dagen en cascadeert naar **AlertingRulesError + RequestErrorsToAPI + TooManyLogs**.

## Fix
Linkerzijde in `max by(cluster,pool_id,instance)(...)` wikkelen → dedup → query werkt weer (geverifieerd tegen live vmsingle: `status: success`, geen 422). Geleverd als postRenderer-patch naast de bestaande `node_filesystem`-fix; een JSON6902 `test`-op guard't de regel-index.

## Herkomst
Niet uit onedr0p/buroa (die draaien kube-prometheus-stack en raken deze VM-specifieke bug niet). Eigen fix, geverifieerd, consistent met het bestaande postRenderer-patroon in deze repo. Echte fix, geen mute.

## Effect
Ruimt de cascade (3 alerts) permanent op; alleen `Watchdog` (dead-man's switch → null) blijft.