### PR TITLE
fix(qbittorrent): gluetun custom provider for ProtonVPN (fixes VPN crash / no downloads)

### DIFF
--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -48,9 +48,15 @@ spec:
             env:
               DOT: "off"
               DNS_ADDRESS: "10.2.0.1"
-              VPN_SERVICE_PROVIDER: protonvpn
+              # custom (not protonvpn): with the protonvpn provider gluetun
+              # validates WIREGUARD_ENDPOINT_IP against its bundled server list,
+              # which goes stale as ProtonVPN rotates servers -> "target IP not
+              # found" crash. custom uses the pinned endpoint directly. (matches
+              # bjw-s-labs/home-ops gluetun era)
+              VPN_SERVICE_PROVIDER: custom
               VPN_TYPE: wireguard
               VPN_INTERFACE: wg0
+              WIREGUARD_ENDPOINT_PORT: 51820
               VPN_PORT_FORWARDING: on
               VPN_PORT_FORWARDING_PROVIDER: protonvpn
               FIREWALL_INPUT_PORTS: 8080


### PR DESCRIPTION
## Probleem
gluetun stond op `VPN_SERVICE_PROVIDER: protonvpn` met een gepinde `WIREGUARD_ENDPOINT_IP`. De `protonvpn`-provider valideert die IP tegen gluetun's gebundelde serverlijst; ProtonVPN roteert servers en de lijst (v3.41.1) bevat de huidige IP's niet meer → `target IP address not found` → VPN crasht → geen tunnel → qbittorrent downloadt niks (sinds ~27 mei).

## Fix
`VPN_SERVICE_PROVIDER: custom` + `WIREGUARD_ENDPOINT_PORT: 51820` → gluetun verbindt rechtstreeks met de gepinde endpoint/key uit de secret, zonder serverlijst-lookup. Matcht de bjw-s-labs gluetun-config waar dit op gebaseerd is. Secret levert al `WIREGUARD_{ENDPOINT_IP,PUBLIC_KEY,PRIVATE_KEY,ADDRESSES}` (net ververst in 1Password).