### PR TITLE
fix(qbittorrent): protonvpn provider, dynamic server (no pinned endpoint)

### DIFF
--- a/kubernetes/apps/downloads/qbittorrent/app/externalsecret.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/externalsecret.yaml
@@ -12,14 +12,10 @@ spec:
     name: *name
     creationPolicy: Owner
   data:
-    - secretKey: WIREGUARD_ENDPOINT_IP
-      remoteRef:
-        key: *name
-        property: WIREGUARD_ENDPOINT_IP
-    - secretKey: WIREGUARD_PUBLIC_KEY
-      remoteRef:
-        key: *name
-        property: WIREGUARD_PUBLIC_KEY
+    # WIREGUARD_ENDPOINT_IP / WIREGUARD_PUBLIC_KEY intentionally omitted: with
+    # VPN_SERVICE_PROVIDER=protonvpn gluetun supplies the server endpoint +
+    # public key from its own list. Pinning them caused "target IP not found"
+    # crashes when ProtonVPN rotated servers.
     - secretKey: WIREGUARD_PRIVATE_KEY
       remoteRef:
         key: *name

--- a/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
+++ b/kubernetes/apps/downloads/qbittorrent/app/helmrelease.yaml
@@ -48,15 +48,17 @@ spec:
             env:
               DOT: "off"
               DNS_ADDRESS: "10.2.0.1"
-              # custom (not protonvpn): with the protonvpn provider gluetun
-              # validates WIREGUARD_ENDPOINT_IP against its bundled server list,
-              # which goes stale as ProtonVPN rotates servers -> "target IP not
-              # found" crash. custom uses the pinned endpoint directly. (matches
-              # bjw-s-labs/home-ops gluetun era)
-              VPN_SERVICE_PROVIDER: custom
+              # protonvpn provider: gluetun supplies the server endpoint + public
+              # key from its own list, so we must NOT pin WIREGUARD_ENDPOINT_IP/
+              # PUBLIC_KEY (those are dropped from the externalsecret). Only
+              # WIREGUARD_PRIVATE_KEY (+ ADDRESSES) is required. Select a port-
+              # forward-capable NL server dynamically so ProtonVPN server
+              # rotations don't break the tunnel. (per gluetun ProtonVPN docs)
+              VPN_SERVICE_PROVIDER: protonvpn
               VPN_TYPE: wireguard
               VPN_INTERFACE: wg0
-              WIREGUARD_ENDPOINT_PORT: 51820
+              SERVER_COUNTRIES: Netherlands
+              PORT_FORWARD_ONLY: "on"
               VPN_PORT_FORWARDING: on
               VPN_PORT_FORWARDING_PROVIDER: protonvpn
               FIREWALL_INPUT_PORTS: 8080


### PR DESCRIPTION
Vervolg op #1616. Houdt `VPN_SERVICE_PROVIDER=protonvpn` (zoals gewenst) maar stopt met een server pinnen. Per gluetun's ProtonVPN-docs is met de protonvpn-provider alleen `WIREGUARD_PRIVATE_KEY` nodig; gluetun levert endpoint+public key uit z'n eigen lijst. Het pinnen van `WIREGUARD_ENDPOINT_IP/PUBLIC_KEY` veroorzaakte de `target IP not found`-crash bij serverrotatie.

- helmrelease: `SERVER_COUNTRIES: Netherlands` + `PORT_FORWARD_ONLY: on`, `WIREGUARD_ENDPOINT_PORT` weg
- externalsecret: endpoint-IP + public-key pins weg (private key + addresses blijven)

Overleeft ProtonVPN serverrotaties.