### PR TITLE
fix(rook-ceph): rbd snapshotPolicy=volumeSnapshot (fixes VolSync backups)

### DIFF
--- a/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/ceph-csi-drivers/app/helmrelease.yaml
@@ -16,9 +16,13 @@ spec:
       rbd:
         enabled: true
         name: rook-ceph.rbd.csi.ceph.com
+        # required for VolumeSnapshots (VolSync backups); the chart defaults rbd
+        # to "none", which omits the csi-snapshotter sidecar.
+        snapshotPolicy: volumeSnapshot
       cephfs:
         enabled: true
         name: rook-ceph.cephfs.csi.ceph.com
+        snapshotPolicy: volumeSnapshot
         # preserved from the old rook-ceph csi.cephFSKernelMountOptions setting
         # (Driver CR expects a map, not a string)
         kernelMountOptions:


### PR DESCRIPTION
The ceph-csi-drivers chart defaults rbd `snapshotPolicy: none`, so the ctrlplugin had no csi-snapshotter → ceph-block VolumeSnapshots stuck `readyToUse=false` → all VolSync backups out of sync (`waiting for copy trigger`). Set `snapshotPolicy: volumeSnapshot` for rbd (+ cephfs explicit). Regression from the ceph-csi-drivers migration.