### PR TITLE
fix(actions-runner): bump runner image to 2.334.0 (2.328.0 deprecated)

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/homelab/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/homelab/helmrelease.yaml
@@ -70,7 +70,7 @@ spec:
       spec:
         containers:
           - name: runner
-            image: ghcr.io/home-operations/actions-runner:2.328.0@sha256:c43873ef6800697dfa181582f6bb02366a9a0afb52026bde7bad7c71b21b1052
+            image: ghcr.io/home-operations/actions-runner:2.334.0@sha256:95d91d7f8d241e319ef2f4fec08f417aa1606b96fbb327643f75c303acd30002
             command: ["/home/runner/run.sh"]
             env:
               - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER


### PR DESCRIPTION
GitHub weigert runner v2.328.0 (*'deprecated and cannot receive messages'*) → de runner registreerde en exitte elke poll → ARC recreëerde 'm in een loop (RUNNERID 167). ARC draait met disableUpdate (image-managed), dus 't image moet nieuwer. Bump naar 2.334.0 (latest); Renovate houdt 't voortaan bij.