### PR TITLE
feat(ci): AI PR review (self-hosted runner + LiteLLM/gpt-4.1-mini)

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -1,0 +1,22 @@
+---
+name: AI PR Review
+on:
+  pull_request:
+    branches: ["main"]
+    types: ["opened", "reopened", "synchronize", "ready_for_review"]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  review:
+    runs-on: homelab-runner
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: AI review
+        uses: davealtena/pr-reviewer@main
+        with:
+          ai_base_url: http://litellm.ai.svc.cluster.local:4000/v1
+          ai_model: gpt-4.1-mini
+          ai_api_key: ${{ secrets.LITELLM_API_KEY }}
+          standards_file: AGENTS.md

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: AI review
-        uses: davealtena/pr-reviewer@main
+        uses: davealtena/pr-reviewer@v1.0.0
         with:
           ai_base_url: http://litellm.ai.svc.cluster.local:4000/v1
           ai_model: gpt-4.1-mini


### PR DESCRIPTION
Draait `davealtena/pr-reviewer` op `homelab-runner` (intern → bereikt LiteLLM zonder exposen), reviewt elke PR-diff tegen `AGENTS.md` met `gpt-4.1-mini`. Key uit repo-secret `LITELLM_API_KEY`.

Deze PR is meteen de eerste test — de review zou hieronder als comment moeten verschijnen. 🤖