### PR TITLE
ci(pr-review): PR Review Standards + skip Renovate/bot PRs

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -9,6 +9,9 @@ permissions:
   pull-requests: write
 jobs:
   review:
+    # Skip Renovate/bot PRs — without tool access the reviewer can't read changelogs,
+    # so reviewing version bumps is just noise. Only review human (your) PRs.
+    if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
     runs-on: homelab-runner
     steps:
       - name: Checkout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,3 +63,36 @@ Non-obvious "why is it like this" facts you can't infer from a single file:
 - Conventional commits + `--signoff` (`-s`).
 - When adding/changing an app, copy the structure and schema headers of a nearby existing app rather than inventing fields.
 - Verify against authoritative docs / proven references before hand-rolling config; cite the source.
+
+## PR Review Standards
+
+Instructions for the AI PR reviewer. It sees **only the PR diff plus this file** — no
+tool access, so don't reason about changelogs or upstream release notes it can't fetch.
+Renovate/bot PRs are out of scope (the workflow skips them). Be quiet unless there's a
+real problem; only `critical`/`high` fail the check. Default to silence over nitpicking.
+
+**Flag (high-value, evaluable from the diff):**
+
+- **Leaked secrets** → `critical`. Any plaintext credential/token/key/password added
+  inline. Secrets MUST be `external-secrets` (1Password) or SOPS-encrypted. A SOPS
+  ciphertext blob or an `ExternalSecret`/`*SecretStore` reference is correct, not a leak.
+- **Security/privilege relaxations** → `high`. `privileged: true`, `hostNetwork`/`hostPID`,
+  dropping a `securityContext`/`readOnlyRootFilesystem`, loosening a Pod Security
+  Admission label (e.g. `restricted` → `privileged`), or broad RBAC (`cluster-admin`,
+  `*` verbs/resources) — unless the diff/commit gives a clear reason.
+- **Broken GitOps structure** → `high`. A new app missing its `ks.yaml` (or not wired
+  into the namespace `kustomization.yaml`), a HelmRelease/OCIRepository with an unpinned
+  version/tag, or a missing/wrong schema header.
+- **Breaking / data-loss changes** → `high` (or `critical` for data loss). Removing or
+  renaming a resource others depend on, API-version or CRD changes, deleting a PVC, or
+  changing a StorageClass / reclaim policy.
+- **Correctness bugs in changed lines** → severity to taste. YAML that won't parse,
+  wrong namespace/selector, typo'd image ref.
+
+**Do NOT flag (known-good here — avoids false positives):**
+
+- Internal `*.svc.cluster.local` URLs, ClusterIP endpoints, or private RFC1918 IPs. CI
+  runs on the in-cluster `homelab-runner`, so these ARE reachable — never say "internal
+  URL not reachable from CI/GitHub".
+- "This won't take effect" — changes apply via Flux after merge; that's expected.
+- Missing CPU/memory limits or requests — a style preference here, not a blocker.


### PR DESCRIPTION
## What

- **AGENTS.md** → new `## PR Review Standards` section: tells the AI reviewer what to flag from a diff (leaked secrets, privilege/RBAC relaxations, broken GitOps structure, breaking/data-loss changes, correctness bugs) and — importantly — what *not* to flag (internal `*.svc` URLs are reachable from the in-cluster runner; Flux applies after merge; missing resource limits are style). This kills the internal-URL false positive seen on #1633.
- **ai-pr-review.yaml** → `if: !endsWith(user.login, '[bot]')` so the reviewer runs on human PRs only.

## Why

Modeled on JoryIrving's AGENTS.md "PR Review Standards" approach (instructions live in the standards file), but adapted: our reviewer has **no tool access**, so it can't fetch changelogs — reviewing Renovate version bumps would just be noise. Skip bots; focus the toolless reviewer on what it can actually evaluate from a diff. Fetching release notes (Jory-style) is a future upgrade.