### PR TITLE
ci(renovate): gate majors + critical-infra minors for review

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -3,15 +3,19 @@ name: AI PR Review
 on:
   pull_request:
     branches: ["main"]
-    types: ["opened", "reopened", "synchronize", "ready_for_review"]
+    types: ["opened", "reopened", "synchronize", "ready_for_review", "labeled"]
 permissions:
   contents: read
   pull-requests: write
 jobs:
   review:
-    # Skip Renovate/bot PRs — without tool access the reviewer can't read changelogs,
-    # so reviewing version bumps is just noise. Only review human (your) PRs.
-    if: ${{ !endsWith(github.event.pull_request.user.login, '[bot]') }}
+    # Review human PRs, plus the gated Renovate PRs (majors + cluster-critical infra,
+    # labeled review/required by Renovate). Trivial bumps auto-merge silently and are
+    # skipped — without tool access the reviewer can't read changelogs, so reviewing
+    # routine version bumps is just noise.
+    if: >-
+      ${{ !endsWith(github.event.pull_request.user.login, '[bot]')
+          || contains(github.event.pull_request.labels.*.name, 'review/required') }}
     runs-on: homelab-runner
     steps:
       - name: Checkout

--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -20,7 +20,41 @@
         "Force manual review so upgrades land in a known maintenance window."
       ],
       "matchPackageNames": ["ghcr.io/siderolabs/installer"],
-      "automerge": false
+      "automerge": false,
+      "reviewers": ["davealtena"],
+      "addLabels": ["review/required"]
+    },
+    {
+      "description": [
+        "All major bumps: never auto-merge (the default, made explicit) and pull",
+        "me in — request review + label so the AI reviewer runs and GitHub",
+        "notifies me. Trivial minor/patch/digest stay silently auto-merged."
+      ],
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "reviewers": ["davealtena"],
+      "addLabels": ["review/required"]
+    },
+    {
+      "description": [
+        "Cluster-critical charts: a semver-MINOR here can be breaking (rook-ceph",
+        "1.19->1.20 changed CSI RBAC and broke storage). Don't auto-merge their",
+        "minors — request review + label so I approve in a maintenance window."
+      ],
+      "matchDatasources": ["docker"],
+      "matchPackagePatterns": [
+        "rook/rook-ceph",
+        "cilium/charts/cilium",
+        "cloudnative-pg/charts",
+        "external-secrets/charts",
+        "envoyproxy/gateway-helm",
+        "jetstack/charts/cert-manager",
+        "controlplaneio-fluxcd/charts"
+      ],
+      "matchUpdateTypes": ["minor"],
+      "automerge": false,
+      "reviewers": ["davealtena"],
+      "addLabels": ["review/required"]
     }
   ]
 }


### PR DESCRIPTION
## Why

Renovate currently auto-merges all non-breaking container updates incl. **minors**. But a semver-*minor* on a cluster-critical chart can be breaking — **rook-ceph 1.19→1.20 was a minor** that changed CSI RBAC and broke storage. "Review only majors" wouldn't have caught it.

Goal (Dave): keep **trivial** container-app updates auto-merging (no noise), but pull in **majors + critical-infra minors** for manual approval + AI review — and only get GitHub mail for *those*.

## What

**`.renovate/overrides.json5`** (mirrors the existing Talos-installer `automerge:false` precedent):
- All `major` updates → `automerge:false` + `reviewers:[davealtena]` + `review/required` label.
- Minors of cluster-critical charts (rook-ceph, cilium, cloudnative-pg, external-secrets, envoy-gateway, cert-manager, flux) → same treatment.
- Talos installer rule → also gets reviewer + label now.
- Everything else (container app minor/patch/digest) → unchanged, silent auto-merge.

**`.github/workflows/ai-pr-review.yaml`**:
- Runs on human PRs **OR** `review/required` PRs (added `labeled` trigger).

## The notification piece (manual, GitHub UI)

Set repo watching to **"Participating and @mentions only"**. Then the only Renovate PRs that mail you are the gated ones (where Renovate now requests you as reviewer). Trivial auto-merges go silent.

Validated with `renovate-config-validator --strict` (exit 0).