### PR TITLE
ci(pr-review): @mention on gated PRs (pr-reviewer v1.2.0)

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -21,9 +21,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: AI review
-        uses: davealtena/pr-reviewer@v1.1.0
+        uses: davealtena/pr-reviewer@v1.2.0
         with:
           ai_base_url: http://litellm.ai.svc.cluster.local:4000/v1
           ai_model: gpt-4.1-mini
           ai_api_key: ${{ secrets.LITELLM_API_KEY }}
           standards_file: AGENTS.md
+          # Gated PRs (majors / critical-infra, labeled review/required) need my
+          # manual merge — @mention me and always post a comment (even when clean)
+          # so I'm notified under "@mentions only". My own PRs: stay silent unless findings.
+          mention: ${{ contains(github.event.pull_request.labels.*.name, 'review/required') && 'davealtena' || '' }}
+          always_comment: ${{ contains(github.event.pull_request.labels.*.name, 'review/required') }}


### PR DESCRIPTION
Bumps the reviewer to v1.2.0 and, on `review/required` PRs (majors / critical-infra that need manual merge), `@mention`s me + posts a comment even when the review is clean — so I get a GitHub notification under "@mentions only". My own PRs are unchanged: silent unless there are findings.

Pairs with #1635 (the gate) so the only Renovate PRs that ping me are the ones I actually need to merge.