### PR TITLE
ci(pr-review): feed PR description to reviewer (v1.3.0)

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: AI review
-        uses: davealtena/pr-reviewer@v1.2.0
+        uses: davealtena/pr-reviewer@v1.3.0
         with:
           ai_base_url: http://litellm.ai.svc.cluster.local:4000/v1
           ai_model: gpt-4.1-mini

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,10 +66,12 @@ Non-obvious "why is it like this" facts you can't infer from a single file:
 
 ## PR Review Standards
 
-Instructions for the AI PR reviewer. It sees **only the PR diff plus this file** — no
-tool access, so don't reason about changelogs or upstream release notes it can't fetch.
-Renovate/bot PRs are out of scope (the workflow skips them). Be quiet unless there's a
-real problem; only `critical`/`high` fail the check. Default to silence over nitpicking.
+Instructions for the AI PR reviewer. It sees the **PR diff, the PR description, and this
+file**. For dependency-bot PRs (Renovate) the description embeds upstream release
+notes/changelogs — use them to judge whether a bump is breaking. Routine bumps
+auto-merge and are skipped; only **gated** bot PRs reach the reviewer (majors +
+cluster-critical charts, labeled `review/required`). Be quiet unless there's a real
+problem; only `critical`/`high` fail the check. Default to silence over nitpicking.
 
 **Flag (high-value, evaluable from the diff):**
 


### PR DESCRIPTION
The reviewer now gets the PR **title + description** alongside the diff. Renovate embeds upstream release notes in the PR body (you have changelogs enabled), so on a gated dependency bump (e.g. a rook-ceph minor) the reviewer can actually read the changelog and flag breaking changes — the Jory-style 'fetch release notes' value, but via the PR body instead of an agentic gh_api loop (more robust, fits the stdlib-only design).

- pr-reviewer → v1.3.0 (feeds title+body, body capped 24k, best-effort fetch)
- AGENTS.md PR Review Standards updated to match.