### PR TITLE
feat(ci): implement-agent (issue → draft PR, gated)

### DIFF
--- a/.github/workflows/agent-implement.yaml
+++ b/.github/workflows/agent-implement.yaml
@@ -1,0 +1,133 @@
+---
+# Implement-agent: turns a GitHub issue into a draft PR.
+#
+# Safe-by-default. To ACTIVATE (Dave, one-time):
+#   1. Create a write-scoped credential and store it as repo secret
+#      AGENT_GITHUB_TOKEN — a fine-grained PAT (or GitHub App token) with
+#      Contents: read/write + Pull requests: read/write on this repo. (Not the
+#      default GITHUB_TOKEN — PRs it opens wouldn't trigger the AI reviewer.)
+#   2. Create the `agent/implement` label.
+#   3. Recommended: protect `main` (require a PR + the `review` check) so nothing
+#      the agent produces can land without your review.
+#
+# How it runs: add the `agent/implement` label to an issue → the agent (opencode
+# + LiteLLM, reads AGENTS.md) implements it on a branch and opens a DRAFT PR
+# labeled `review/required`. That PR is gated by the AI reviewer + your manual
+# merge. It is never auto-merged, and the agent never pushes to main.
+name: Agent — implement issue
+on:
+  issues:
+    types: ["labeled"]
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+jobs:
+  implement:
+    # Opt-in per issue: only when you add the `agent/implement` label.
+    if: github.event.label.name == 'agent/implement'
+    runs-on: homelab-runner
+    steps:
+      - name: Require bot token (inert until activated)
+        env:
+          AGENT_GITHUB_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          if [ -z "$AGENT_GITHUB_TOKEN" ]; then
+            echo "AGENT_GITHUB_TOKEN not set — implement-agent is not activated (see workflow header)."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Bot token so the draft PR triggers the AI review workflow.
+          token: ${{ secrets.AGENT_GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Install opencode
+        shell: bash
+        run: |
+          curl -fsSL https://opencode.ai/install | bash
+          echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
+
+      - name: Write opencode config (LiteLLM provider)
+        shell: bash
+        run: |
+          cat > opencode.json <<'JSON'
+          {
+            "$schema": "https://opencode.ai/config.json",
+            "provider": {
+              "litellm": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "LiteLLM (homelab)",
+                "options": {
+                  "baseURL": "http://litellm.ai.svc.cluster.local:4000/v1",
+                  "apiKey": "{env:LITELLM_API_KEY}"
+                },
+                "models": {
+                  "gpt-4.1": { "name": "gpt-4.1" }
+                }
+              }
+            }
+          }
+          JSON
+
+      - name: Prepare branch
+        id: prep
+        shell: bash
+        run: |
+          git config user.name "homelab-agent"
+          git config user.email "agent@altena.io"
+          branch="agent/issue-${{ github.event.issue.number }}"
+          git checkout -b "$branch"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Implement issue
+        env:
+          LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+        shell: bash
+        run: |
+          # Build the prompt without shell-interpolating issue text (printf '%s'
+          # treats $(...) / backticks in the body as literal data — no injection).
+          {
+            echo "You are implementing GitHub issue #${ISSUE_NUM} in this GitOps homelab repo."
+            echo "Read AGENTS.md first and follow its conventions EXACTLY — copy the structure"
+            echo "and schema headers of a nearby existing app rather than inventing fields."
+            echo "Make the MINIMAL change needed for this issue. Do NOT commit plaintext"
+            echo "secrets (use the external-secrets / SOPS patterns). Do NOT touch unrelated"
+            echo "files. If the task is unclear or unsafe, make NO changes and say why."
+            echo
+            printf 'Issue title: %s\n\n' "$ISSUE_TITLE"
+            echo "Issue body:"
+            printf '%s\n' "$ISSUE_BODY"
+          } > /tmp/agent-prompt.txt
+          opencode run --model litellm/gpt-4.1 "$(cat /tmp/agent-prompt.txt)"
+
+      - name: Open draft PR
+        env:
+          GH_TOKEN: ${{ secrets.AGENT_GITHUB_TOKEN }}
+          # Via env (not ${{ }} in the script) to avoid shell injection from issue text.
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          BRANCH: ${{ steps.prep.outputs.branch }}
+        shell: bash
+        run: |
+          rm -f opencode.json  # don't commit the generated config
+          if git diff --quiet && git diff --cached --quiet; then
+            gh issue comment "$ISSUE_NUM" \
+              --body "🤖 implement-agent made no changes (task unclear/unsafe, or nothing to do)."
+            exit 0
+          fi
+          git add -A
+          git commit -s -m "feat: implement #${ISSUE_NUM} via agent" -m "${ISSUE_TITLE}" -m "Closes #${ISSUE_NUM}"
+          git push -u origin "$BRANCH"
+          gh label create review/required --color FFAA00 \
+            --description "Needs Dave's manual review/merge" --force >/dev/null 2>&1 || true
+          gh pr create --draft --base main --head "$BRANCH" \
+            --label review/required \
+            --title "feat: implement #${ISSUE_NUM} (agent)" \
+            --body "$(printf 'Implements #%s — %s\n\nGenerated by the implement-agent (opencode + LiteLLM, gpt-4.1).\n\n@davealtena — **draft** for your review. Gated by AI review + your manual merge; never auto-merged. Review the diff before marking ready/merging.' "$ISSUE_NUM" "$ISSUE_TITLE")"


### PR DESCRIPTION
Part 2 of the agentic pipeline: an implementer that turns an issue into a **draft PR**, gated by the AI reviewer + your manual merge.

## Safety model (why this is safe to merge now)
- **Inert until you activate it.** A guard step fails the run unless `AGENT_GITHUB_TOKEN` is set, and it only triggers on the `agent/implement` label (which doesn't exist yet). Merging the file does nothing on its own.
- **Opt-in per issue** — you add the label; nothing runs automatically.
- **Draft PR only**, to `main`, labeled `review/required`, @mentioning you. Never pushes to main, never auto-merges. Goes through the same AI review + your merge.
- **Bot token** (not default GITHUB_TOKEN) so the draft PR actually triggers the reviewer.
- **Injection-safe**: issue title/body passed via env, never interpolated into shell.
- Runs on the ephemeral, minimal-RBAC `homelab-runner` (no cluster-admin/talos).

## Engine
opencode (reads AGENTS.md natively) → in-cluster LiteLLM → gpt-4.1 (swap in one line, like the reviewer). Mirrors JoryIrving's opencode-based dispatch, adapted to your stack.

## To activate (your steps — see the workflow header)
1. Create a fine-grained PAT (Contents + Pull requests: write) → repo secret `AGENT_GITHUB_TOKEN`.
2. Create the `agent/implement` label.
3. Recommended: protect `main` (require PR + the `review` check).

⚠️ First real run is the validation — opencode's headless tool-execution behavior in CI is the one thing I couldn't test without the token + a live issue.