### PR TITLE
fix(ci): truncate flux-diff output to stay within GitHub limits

### DIFF
--- a/.github/workflows/flux-diff.yaml
+++ b/.github/workflows/flux-diff.yaml
@@ -33,6 +33,8 @@ jobs:
         id: diff
         run: |
           output=$(flate diff all --path ./kubernetes 2>&1 || true)
+          # Truncate to stay within GitHub output and comment size limits
+          output=$(echo "${output}" | head -c 60000)
           echo "diff<<EOF" >> $GITHUB_OUTPUT
           echo "${output}" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Large diffs (e.g. Grafana dashboard ConfigMap JSON) exceed GitHub's output and PR comment size limits, causing the Flux Diff job to fail. Truncate at 60KB.