### PR TITLE
feat(databases): make homelab Postgres HA (instances: 2)

### DIFF
--- a/kubernetes/apps/databases/cnpg/cluster/cluster.yaml
+++ b/kubernetes/apps/databases/cnpg/cluster/cluster.yaml
@@ -6,7 +6,7 @@ metadata:
   name: homelab
 spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:16.9-22
-  instances: 1
+  instances: 2
   primaryUpdateStrategy: unsupervised
   storage:
     size: 10Gi


### PR DESCRIPTION
## Why

`homelab` CNPG runs **single-instance** (`instances: 1`), with `homelab-1` pinned to **baldur**. The `homelab-primary` PDB allows **0 disruptions** and there is no replica to fail over to, so **draining baldur is impossible** — the primary pod can never be evicted.

Result: every Talos node upgrade that reaches baldur hangs on the drain → Tuppr marks the batch `Job failed permanently` → baldur is left cordoned. This is the actual root cause of the recurring 'upgrade stuck' (history shows baldur failed on v1.13.0 and v1.13.3), **not** the Talos version.

## Change

Bump to `instances: 2`. CNPG then performs a **switchover to the replica** when baldur is drained, so node maintenance/upgrades complete cleanly. Default pod anti-affinity (preferred, hostname topology) places the replica on a different node.

## Follow-up (not in this PR)
- No `barmanObjectStore` backup is configured for this cluster — worth adding separately.