### PR TITLE
fix(observability): use `token` not `apiToken` in AlertmanagerConfig pushover

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -70,7 +70,7 @@ spec:
           sound: gamelan
           title: >-
             [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}
-          apiToken:
+          token:
             name: alertmanager-secret
             key: ALERTMANAGER_TOKEN
           userKey:


### PR DESCRIPTION
## Problem

No alerts are being delivered. The `kube-prometheus-stack` Flux kustomization is **failing**:

```
AlertmanagerConfig/observability/alertmanager dry-run failed: ...
.spec.receivers[name="pushover"].pushoverConfigs[0].apiToken: field not declared in schema
```

The `pushoverConfigs` schema (monitoring.coreos.com/v1alpha1) has **no `apiToken`** field — it's **`token`** (verified via `kubectl explain`). The invalid field fails server-side dry-run, which blocks the **entire** `kube-prometheus-stack/app` kustomization: `alertmanager-secret` (ExternalSecret) is absent, the HelmRelease never applied, and **Prometheus/Alertmanager were never deployed** → no alerts.

## Fix

Rename `apiToken` → `token` (the `alertmanager-secret` / `ALERTMANAGER_TOKEN` ref is unchanged). This unblocks the kustomization so the full stack rolls out.