### PR TITLE
feat(ai): add Home Assistant and UniFi MCP servers

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/externalsecret.yaml
@@ -58,3 +58,44 @@ spec:
   dataFrom:
     - extract:
         key: toolhive
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: toolhive-hass
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: toolhive-hass
+    creationPolicy: Owner
+    template:
+      data:
+        HA_TOKEN: "{{ .HA_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: toolhive
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: toolhive-unifi
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: toolhive-unifi
+    creationPolicy: Owner
+    template:
+      data:
+        UNIFI_USERNAME: "{{ .UNIFI_USERNAME }}"
+        UNIFI_PASSWORD: "{{ .UNIFI_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: toolhive

--- a/kubernetes/apps/ai/toolhive/config/app/hass-mcp.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/hass-mcp.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: hass-mcp
+spec:
+  image: docker.io/voska/hass-mcp:0.4.1
+  transport: stdio
+  proxyMode: streamable-http
+  proxyPort: 8080
+  env:
+    - name: HA_URL
+      value: http://home-assistant.home-automation.svc.cluster.local:8123
+  secrets:
+    - name: toolhive-hass
+      key: HA_TOKEN
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/ai/toolhive/config/app/kustomization.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/kustomization.yaml
@@ -7,5 +7,7 @@ resources:
   - ./kubectl-mcp.yaml
   - ./github-mcp.yaml
   - ./garmin-mcp.yaml
+  - ./hass-mcp.yaml
+  - ./unifi-mcp.yaml
   - ./mcpgroup.yaml
   - ./virtualmcpserver.yaml

--- a/kubernetes/apps/ai/toolhive/config/app/unifi-mcp.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/unifi-mcp.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: unifi-network-mcp
+spec:
+  image: ghcr.io/sirkirby/unifi-network-mcp:sha-b716164
+  transport: stdio
+  proxyMode: streamable-http
+  proxyPort: 8080
+  env:
+    - name: UNIFI_HOST
+      value: "192.168.1.1"
+    - name: UNIFI_PORT
+      value: "443"
+    # UniFi controller uses a self-signed cert
+    - name: UNIFI_VERIFY_SSL
+      value: "false"
+  secrets:
+    - name: toolhive-unifi
+      key: UNIFI_USERNAME
+    - name: toolhive-unifi
+      key: UNIFI_PASSWORD
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      memory: 384Mi
+  groupRef:
+    name: mcp-tools


### PR DESCRIPTION
Adds two MCP servers to the Toolhive `mcp-tools` group (used by Hermes via the virtual MCP gateway).

## Servers
| Server | Image | Talks to | Auth |
|---|---|---|---|
| `hass-mcp` | `voska/hass-mcp:0.4.1` | `home-assistant.home-automation.svc:8123` (in-cluster) | `HA_TOKEN` (long-lived token) |
| `unifi-network-mcp` | `ghcr.io/sirkirby/unifi-network-mcp:sha-b716164` | UniFi controller `192.168.1.1` | `UNIFI_USERNAME` + `UNIFI_PASSWORD` |

Both run over stdio behind Toolhive's streamable-http proxy, same pattern as the existing github/garmin MCPs.

## ⚠️ Required before this works: add 3 secrets to 1Password
Add these properties to the existing **`toolhive`** item (same item the github/garmin keys live in):
- `HA_TOKEN` — a Home Assistant **long-lived access token** (HA → profile → Long-lived tokens)
- `UNIFI_USERNAME` / `UNIFI_PASSWORD` — a UniFi **local admin** account (recommend a dedicated, limited one — an LLM agent gets these)

Until then the ExternalSecrets won't sync and the pods won't start. **Do not merge before the secrets exist.**

## Notes
- UniFi uses user/pass for full tool coverage. `sirkirby` also supports a read-only `UNIFI_API_KEY` (you already have one for external-dns) — swap the env/secret if you prefer least-privilege.
- `UNIFI_VERIFY_SSL=false` (self-signed controller cert).
- UniFi image has no semver tags upstream (only `sha-*`); pinned to a digest-style sha, so Renovate won't auto-bump it.