### PR TITLE
fix(ai): split UniFi MCP into two secrets (unblock toolhive-config)

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/externalsecret.yaml
@@ -83,18 +83,37 @@ spec:
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: toolhive-unifi
+  name: toolhive-unifi-username
 spec:
   refreshInterval: 12h
   secretStoreRef:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: toolhive-unifi
+    name: toolhive-unifi-username
     creationPolicy: Owner
     template:
       data:
         UNIFI_USERNAME: "{{ .UNIFI_USERNAME }}"
+  dataFrom:
+    - extract:
+        key: toolhive
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: toolhive-unifi-password
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: toolhive-unifi-password
+    creationPolicy: Owner
+    template:
+      data:
         UNIFI_PASSWORD: "{{ .UNIFI_PASSWORD }}"
   dataFrom:
     - extract:

--- a/kubernetes/apps/ai/toolhive/config/app/unifi-mcp.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/unifi-mcp.yaml
@@ -17,9 +17,9 @@ spec:
     - name: UNIFI_VERIFY_SSL
       value: "false"
   secrets:
-    - name: toolhive-unifi
+    - name: toolhive-unifi-username
       key: UNIFI_USERNAME
-    - name: toolhive-unifi
+    - name: toolhive-unifi-password
       key: UNIFI_PASSWORD
   resources:
     requests:


### PR DESCRIPTION
MCPServer `.spec.secrets` is keyed on `.name`; two entries named `toolhive-unifi` failed server-side apply with `duplicate entries for key [name="toolhive-unifi"]`, which blocked the entire `toolhive-config` kustomization (so even hass-mcp didn't deploy).

Fix: one secret per credential (`toolhive-unifi-username` + `toolhive-unifi-password`), matching the existing garmin MCP pattern. The 1Password item and property names (`toolhive` → `UNIFI_USERNAME`/`UNIFI_PASSWORD`) are unchanged.

Verified with `kubectl apply --dry-run=server` (passes).