### PR TITLE
fix(ai): set PYTHONPATH=/app for UniFi MCP (image entrypoint bug)

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/app/unifi-mcp.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/unifi-mcp.yaml
@@ -9,6 +9,10 @@ spec:
   proxyMode: streamable-http
   proxyPort: 8080
   env:
+    # The image's entrypoint runs /app/src/main.py without /app on the path,
+    # so `import src...` fails (ModuleNotFoundError). Put /app on PYTHONPATH.
+    - name: PYTHONPATH
+      value: /app
     - name: UNIFI_HOST
       value: "192.168.1.1"
     - name: UNIFI_PORT


### PR DESCRIPTION
The `unifi-network-mcp` image's entrypoint runs `/app/src/main.py` without `/app` on the path, so `import src...` fails (`ModuleNotFoundError: No module named 'src'`) and the pod crashloops. Set `PYTHONPATH=/app`.

Verified: `python -c 'import src.managers.connection_manager'` succeeds with `PYTHONPATH=/app` in a throwaway pod of the same image. hass-mcp already works; this is the last blocker for unifi-network-mcp.