### PR TITLE
fix(ai): set UNIFI_SITE=default for UniFi MCP

### DIFF
--- a/kubernetes/apps/ai/toolhive/config/app/unifi-mcp.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/unifi-mcp.yaml
@@ -17,6 +17,8 @@ spec:
       value: "192.168.1.1"
     - name: UNIFI_PORT
       value: "443"
+    - name: UNIFI_SITE
+      value: default
     # UniFi controller uses a self-signed cert
     - name: UNIFI_VERIFY_SSL
       value: "false"


### PR DESCRIPTION
After fixing PYTHONPATH, the UniFi MCP failed with `InterpolationKeyError: UNIFI_SITE` — its `/app/config/config.yaml` interpolates `UNIFI_SITE` (OmegaConf) which was unset. Enumerated the config's required keys; `UNIFI_SITE` was the only missing one. Set it to `default` (the standard UniFi site).