### PR TITLE
fix(ai): run hermes-inframan as a single container (dashboard via env)

### DIFF
--- a/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
@@ -45,6 +45,12 @@ spec:
               HERMES_HOME: /opt/data
               HOME: /opt/data
               TZ: Europe/Amsterdam
+              # Run the dashboard as a supervised s6 service inside this same
+              # container. A second container sharing /opt/data would also
+              # supervise the gateway profile and race for the Discord token
+              # and s6 log lock. Ref: hermes-agent docker docs.
+              HERMES_DASHBOARD: "1"
+              HERMES_DASHBOARD_INSECURE: "1"
             envFrom:
               - secretRef:
                   name: hermes-inframan
@@ -57,25 +63,8 @@ spec:
               - containerPort: &port 8642
                 name: http
                 protocol: TCP
-
-          dashboard:
-            image: *image
-            env:
-              TZ: Europe/Amsterdam
-              GATEWAY_HEALTH_URL: http://localhost:8642
-            args:
-              - dashboard
-              - --host
-              - "0.0.0.0"
-              - --insecure
-            resources:
-              requests:
-                cpu: 50m
-              limits:
-                memory: 1Gi
-            ports:
               - containerPort: &dashboardPort 9119
-                name: http
+                name: dashboard
                 protocol: TCP
 
     service:


### PR DESCRIPTION
## Problem
inframan wasn't showing up in Discord. Its pod runs **two** containers (`app` + `dashboard`) from the same `nousresearch/hermes-agent` image, both mounting the config PVC at `/opt/data` (`HERMES_HOME`). Because the gateway profile + s6 supervise state live on that shared volume, **both containers' s6-overlay supervised the gateway**, so two gateways raced for:
- the **Discord bot token** → `Discord bot token already in use (PID …)`
- the **s6 log lock** → `s6-log: fatal: unable to lock /opt/data/logs/gateways/default/lock: Resource busy`

marja has the same layout and happened to win the race (0 restarts); inframan wedged after a restart.

## Fix
Collapse to a **single container** and enable the dashboard as a supervised s6 service via env — the [documented pattern](https://hermes-agent.nousresearch.com/docs/user-guide/docker): `HERMES_DASHBOARD=1` + `HERMES_DASHBOARD_INSECURE=1`, exposing port 9119 on the same container. No more double-supervision, so the gateway/Discord connection is deterministic.

Follow-up: apply the same to hermes-marja (same latent race).