### PR TITLE
fix(ai): add --no-supervise to hermes-inframan gateway (match joryirving)

### DIFF
--- a/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
@@ -40,17 +40,16 @@ spec:
             image: &image
               repository: nousresearch/hermes-agent
               tag: v2026.5.29
-            args: ["gateway", "run"]
+            # --no-supervise runs the gateway directly instead of via the s6
+            # gateway-default supervise tree. Without it the dashboard container
+            # (same image, shared /opt/data) also supervises the gateway profile,
+            # and the two race for the Discord token + s6 log lock. Matches
+            # joryirving/home-ops.
+            args: ["gateway", "run", "--no-supervise"]
             env:
               HERMES_HOME: /opt/data
               HOME: /opt/data
               TZ: Europe/Amsterdam
-              # Run the dashboard as a supervised s6 service inside this same
-              # container. A second container sharing /opt/data would also
-              # supervise the gateway profile and race for the Discord token
-              # and s6 log lock. Ref: hermes-agent docker docs.
-              HERMES_DASHBOARD: "1"
-              HERMES_DASHBOARD_INSECURE: "1"
             envFrom:
               - secretRef:
                   name: hermes-inframan
@@ -63,8 +62,25 @@ spec:
               - containerPort: &port 8642
                 name: http
                 protocol: TCP
+
+          dashboard:
+            image: *image
+            env:
+              TZ: Europe/Amsterdam
+              GATEWAY_HEALTH_URL: http://localhost:8642
+            args:
+              - dashboard
+              - --host
+              - "0.0.0.0"
+              - --insecure
+            resources:
+              requests:
+                cpu: 50m
+              limits:
+                memory: 1Gi
+            ports:
               - containerPort: &dashboardPort 9119
-                name: dashboard
+                name: http
                 protocol: TCP
 
     service:


### PR DESCRIPTION
Replaces the single-container detour (#1660) with the minimal, proven fix from [joryirving/home-ops](https://github.com/joryirving/home-ops): keep the two-container layout but run the gateway as `gateway run --no-supervise`.

`--no-supervise` runs the gateway directly instead of via the s6 `gateway-default` supervise tree. Without it the `dashboard` container (same image, shared `/opt/data`) also supervises the gateway profile, so two gateways raced for the Discord bot token and the s6 log lock — leaving inframan off Discord.

Follow-up: apply the same one-liner to hermes-marja.