### PR TITLE
feat(ai): give hermes-inframan the hass MCP server

### DIFF
--- a/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
@@ -262,6 +262,8 @@ spec:
                 url: http://mcp-kubectl-mcp-proxy.ai.svc.cluster.local:8080/mcp
               github:
                 url: http://mcp-github-mcp-proxy.ai.svc.cluster.local:8080/mcp
+              hass:
+                url: http://mcp-hass-mcp-proxy.ai.svc.cluster.local:8080/mcp
             discord:
               bot_token: $${DISCORD_BOT_TOKEN}
               allowed_users: $${DISCORD_ALLOWED_USERS}


### PR DESCRIPTION
Adds `hass` to inframan's `mcp_servers` (→ `http://mcp-hass-mcp-proxy.ai.svc.cluster.local:8080/mcp`) so the bot can use the Home Assistant tools.

Note: the "service has no endpoints" concern was a false alarm — `mcp-hass-mcp-proxy` has endpoint `10.69.2.116` and the same selector pattern as the working kubectl/github proxies (the `app=hass-mcp` pod is the StatefulSet workload; the service targets the separate `app=mcpserver` proxy pod). The only missing piece was this config reference. Reloader will restart inframan to pick up the new configmap.