### PR TITLE
Add UniFi Network MCP to hermes-inframan

### DIFF
--- a/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes-inframan/app/helmrelease.yaml
@@ -264,6 +264,8 @@ spec:
                 url: http://mcp-github-mcp-proxy.ai.svc.cluster.local:8080/mcp
               hass:
                 url: http://mcp-hass-mcp-proxy.ai.svc.cluster.local:8080/mcp
+              unifi:
+                url: http://mcp-unifi-network-mcp-proxy.ai.svc.cluster.local:8080/mcp
             discord:
               bot_token: $${DISCORD_BOT_TOKEN}
               allowed_users: $${DISCORD_ALLOWED_USERS}


### PR DESCRIPTION
Adds `unifi-network-mcp-proxy` to hermes-inframan's `mcp_servers` so Inframan can control UniFi devices (APs, switches, gateways).

Diff: only the `unifi:` entry added to the `mcp_servers` block.

After merge, Flux will reconcile and the gateway will pick up the new MCP server. You'll need to restart the gateway (`/restart` in Discord) or wait for the next 30m reconcile cycle.