### PR TITLE
fix(rook-ceph): widen BLUESTORE_SLOW_OP_ALERT thresholds

### DIFF
--- a/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
+++ b/kubernetes/apps/rook-ceph/rook-ceph/cluster/helmrelease.yaml
@@ -49,6 +49,14 @@ spec:
           bdev_enable_discard: "false"
           osd_class_update_on_start: "false"
           mon_clock_drift_allowed: "0.1"
+          # BLUESTORE_SLOW_OP_ALERT defaults are very aggressive (threshold=1 op,
+          # lifetime=24h), so a single transient slow op on the DRAM-less BX500s
+          # parks the cluster in HEALTH_WARN for a day → constant alert flapping
+          # with zero client impact (no blocked requests, PGs clean). Widen to
+          # warn only on *sustained* slowness and clear quickly. The real fix is
+          # enterprise PLP SSDs; blocked-IO/OSD-down have their own checks.
+          bluestore_slow_ops_warn_threshold: "10"
+          bluestore_slow_ops_warn_lifetime: "1800"
       crashCollector:
         disable: false
       dashboard:


### PR DESCRIPTION
Ceph keeps flapping HEALTH_WARN on `BLUESTORE_SLOW_OP_ALERT`. Root cause is the check's very aggressive defaults: **threshold=1** (a single slow op) + **lifetime=24h**, so one transient slow op on the DRAM-less BX500 SSDs parks the cluster in WARN for a day, and every new blip resets it.

Verified zero client impact: no blocked/slow client requests, PGs `active+clean`, 3 OSDs up, 47 GiB used.

Widen so it warns only on *sustained* slowness and self-clears:
- `bluestore_slow_ops_warn_threshold`: 1 → 10
- `bluestore_slow_ops_warn_lifetime`: 86400 → 1800 (30 min)

Not muting a real problem — a genuinely degrading disk (continuous slow ops) still trips this, and blocked-IO / OSD-down / PG health have their own checks (untouched). The real fix remains enterprise PLP SSDs.