### PR TITLE
feat(forgejo): add Forgejo git server

### DIFF
--- a/kubernetes/apps/selfhosted/forgejo/app/externalsecret.yaml
+++ b/kubernetes/apps/selfhosted/forgejo/app/externalsecret.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: forgejo
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: forgejo
+    creationPolicy: Owner
+    template:
+      data:
+        # Admin user (chart gitea.admin.existingSecret)
+        username: "{{ .forgejo_username }}"
+        password: "{{ .forgejo_password }}"
+        email: dave@altena.io
+        # Postgres Init
+        INIT_POSTGRES_DBNAME: forgejo
+        INIT_POSTGRES_HOST: homelab-rw.databases.svc.cluster.local
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+        INIT_POSTGRES_PASS: "{{ .forgejo_db_password }}"
+        INIT_POSTGRES_USER: forgejo
+  dataFrom:
+    - extract:
+        key: forgejo
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "forgejo_$1"
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/selfhosted/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/forgejo/app/helmrelease.yaml
@@ -1,0 +1,80 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: forgejo
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: forgejo
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    # PVC comes from the volsync component (claim name = app name)
+    persistence:
+      enabled: true
+      create: false
+      claimName: forgejo
+
+    service:
+      http:
+        type: ClusterIP
+        port: 3000
+      ssh:
+        type: LoadBalancer
+        port: 22
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: git-ssh.${CLUSTER_DOMAIN}
+
+    gitea:
+      admin:
+        existingSecret: forgejo
+      additionalConfigFromEnvs:
+        - name: FORGEJO__DATABASE__PASSWD
+          valueFrom:
+            secretKeyRef:
+              name: forgejo
+              key: INIT_POSTGRES_PASS
+      metrics:
+        enabled: true
+        serviceMonitor:
+          enabled: true
+      config:
+        APP_NAME: Forgejo
+        server:
+          DOMAIN: git.${CLUSTER_DOMAIN}
+          ROOT_URL: https://git.${CLUSTER_DOMAIN}
+          SSH_DOMAIN: git-ssh.${CLUSTER_DOMAIN}
+          SSH_PORT: 22
+        database:
+          DB_TYPE: postgres
+          HOST: homelab-rw.databases.svc.cluster.local:5432
+          NAME: forgejo
+          USER: forgejo
+        session:
+          PROVIDER: db
+        cache:
+          ADAPTER: memory
+        queue:
+          TYPE: level
+        service:
+          DISABLE_REGISTRATION: true
+        actions:
+          ENABLED: true
+        mirror:
+          ENABLED: true
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 512Mi
+      limits:
+        memory: 1Gi

--- a/kubernetes/apps/selfhosted/forgejo/app/httproute.yaml
+++ b/kubernetes/apps/selfhosted/forgejo/app/httproute.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: forgejo
+spec:
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+      sectionName: https
+  hostnames:
+    - "git.${CLUSTER_DOMAIN}"
+  rules:
+    - backendRefs:
+        - name: forgejo-http
+          port: 3000

--- a/kubernetes/apps/selfhosted/forgejo/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/forgejo/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./httproute.yaml
+  - ./postgres-init-job.yaml

--- a/kubernetes/apps/selfhosted/forgejo/app/ocirepository.yaml
+++ b/kubernetes/apps/selfhosted/forgejo/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: forgejo
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 17.1.1
+  url: oci://code.forgejo.org/forgejo-helm/forgejo

--- a/kubernetes/apps/selfhosted/forgejo/app/postgres-init-job.yaml
+++ b/kubernetes/apps/selfhosted/forgejo/app/postgres-init-job.yaml
@@ -1,0 +1,21 @@
+---
+# The forgejo chart has no init-container hook, so the usual postgres-init
+# pattern runs as a one-shot Job instead (idempotent; force lets Flux
+# recreate it when the spec changes despite Job immutability).
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: forgejo-postgres-init
+  annotations:
+    kustomize.toolkit.fluxcd.io/force: Enabled
+spec:
+  backoffLimit: 6
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: postgres-init
+          image: ghcr.io/onedr0p/postgres-init:17.4
+          envFrom:
+            - secretRef:
+                name: forgejo

--- a/kubernetes/apps/selfhosted/forgejo/ks.yaml
+++ b/kubernetes/apps/selfhosted/forgejo/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &appname forgejo
+  namespace: flux-system
+spec:
+  targetNamespace: selfhosted
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *appname
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: external-secrets-stores
+    - name: volsync
+    - name: rook-ceph-cluster
+    - name: cnpg-cluster
+  interval: 30m
+  timeout: 5m
+  path: "./kubernetes/apps/selfhosted/forgejo/app"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  postBuild:
+    substitute:
+      APP: *appname
+      APP_UID: "1000"
+      APP_GID: "1000"
+      VOLSYNC_CAPACITY: 20Gi
+      VOLSYNC_STORAGECLASS: ceph-block
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool

--- a/kubernetes/apps/selfhosted/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./actual-finance/ks.yaml
+  - ./forgejo/ks.yaml
   - ./mealie/ks.yaml
   - ./n8n/ks.yaml
   - ./paperless/ks.yaml


### PR DESCRIPTION
Official forgejo-helm chart 17.1.1 (Forgejo 15.0.3) in selfhosted:
- CNPG-backed (postgres-init Job; chart has no init-container hook)
- VolSync PVC, admin + db creds via 1Password ExternalSecret
- web via envoy-internal (git.${CLUSTER_DOMAIN}), ssh via its own
  LoadBalancer (git-ssh.${CLUSTER_DOMAIN}, external-dns/unifi)
- Actions enabled for the forgejo-runner that follows

Part 2 of the Forgejo migration (after #1698).

Signed-off-by: Dave Altena <dave@altena.io>
