### PR TITLE
fix(forgejo): rename ExternalSecret target, chart owns Secret 'forgejo'

### DIFF
--- a/kubernetes/apps/selfhosted/forgejo/app/externalsecret.yaml
+++ b/kubernetes/apps/selfhosted/forgejo/app/externalsecret.yaml
@@ -10,7 +10,9 @@ spec:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: forgejo
+    # NOT "forgejo" — the chart itself owns a Secret with that name
+    # (env-to-ini config incl. config_environment.sh)
+    name: forgejo-secret
     creationPolicy: Owner
     template:
       data:

--- a/kubernetes/apps/selfhosted/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/forgejo/app/helmrelease.yaml
@@ -36,12 +36,12 @@ spec:
 
     gitea:
       admin:
-        existingSecret: forgejo
+        existingSecret: forgejo-secret
       additionalConfigFromEnvs:
         - name: FORGEJO__DATABASE__PASSWD
           valueFrom:
             secretKeyRef:
-              name: forgejo
+              name: forgejo-secret
               key: INIT_POSTGRES_PASS
       metrics:
         enabled: true

--- a/kubernetes/apps/selfhosted/forgejo/app/postgres-init-job.yaml
+++ b/kubernetes/apps/selfhosted/forgejo/app/postgres-init-job.yaml
@@ -18,4 +18,4 @@ spec:
           image: ghcr.io/onedr0p/postgres-init:17.4
           envFrom:
             - secretRef:
-                name: forgejo
+                name: forgejo-secret


### PR DESCRIPTION
The chart's env-to-ini config Secret is also named 'forgejo'; the
ExternalSecret overwrote it, breaking the init containers
(config_environment.sh missing). Target is now forgejo-secret.

Signed-off-by: Dave Altena <dave@altena.io>
