### PR TITLE
feat(home-assistant): bidirectional git-sync sidecar for /config

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/externalsecret.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: home-assistant-git-sync
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: home-assistant-git-sync
+    creationPolicy: Owner
+    template:
+      data:
+        FORGEJO_TOKEN: "{{ .forgejo_hass_sync_token }}"
+  dataFrom:
+    - extract:
+        key: forgejo
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "forgejo_$1"

--- a/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/helmrelease.yaml
@@ -60,6 +60,26 @@ spec:
                 memory: 512Mi
               limits:
                 memory: 2Gi
+          git-sync:
+            image:
+              repository: ghcr.io/home-operations/home-assistant
+              tag: 2026.6.2@sha256:124cfd97bf15112d770cd60d1ded0eb8739fb3123b9a32bf85978d4cfa27b1a3
+            command: ["bash", "/scripts/git-sync.sh"]
+            env:
+              SYNC_INTERVAL: "60"
+            envFrom:
+              - secretRef:
+                  name: home-assistant-git-sync
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 5m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
           code-server:
             image:
               repository: ghcr.io/coder/code-server
@@ -146,3 +166,12 @@ spec:
         type: emptyDir
         globalMounts:
           - path: /tmp
+      git-sync-script:
+        type: configMap
+        name: home-assistant-git-sync-script
+        defaultMode: 0755
+        advancedMounts:
+          home-assistant:
+            git-sync:
+              - path: /scripts/git-sync.sh
+                subPath: git-sync.sh

--- a/kubernetes/apps/home-automation/home-assistant/app/kustomization.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/kustomization.yaml
@@ -3,5 +3,14 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+configMapGenerator:
+  - name: home-assistant-git-sync-script
+    files:
+      - ./resources/git-sync.sh
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/home-automation/home-assistant/app/resources/git-sync.sh
+++ b/kubernetes/apps/home-automation/home-assistant/app/resources/git-sync.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Bidirectional git sync for /config <-> in-cluster Forgejo (dave/hass-config).
+# - commits & pushes changes made via the HA UI (mirror propagates to GitHub)
+# - pulls pushes from Forgejo and reloads HA (reload_all; persistent
+#   notification when configuration.yaml/packages change, those need a restart)
+set -uo pipefail
+
+INTERVAL="${SYNC_INTERVAL:-60}"
+BRANCH="${SYNC_BRANCH:-main}"
+
+export GIT_CONFIG_COUNT=4
+export GIT_CONFIG_KEY_0=safe.directory GIT_CONFIG_VALUE_0=/config
+export GIT_CONFIG_KEY_1=user.name GIT_CONFIG_VALUE_1="HA git-sync"
+export GIT_CONFIG_KEY_2=user.email GIT_CONFIG_VALUE_2="hass-git-sync@valhalla.local"
+export GIT_CONFIG_KEY_3=credential.username GIT_CONFIG_VALUE_3="${FORGEJO_USER:-dave}"
+export GIT_ASKPASS=/tmp/git-askpass.sh
+printf '#!/bin/sh\necho "$FORGEJO_TOKEN"\n' > "$GIT_ASKPASS"
+chmod 700 "$GIT_ASKPASS"
+
+cd /config
+
+ha_call() { # $1 = API path, $2 = JSON body
+  [[ -z "${HASS_TOKEN:-}" ]] && return 0
+  curl -fsS -m 10 -o /dev/null -X POST \
+    -H "Authorization: Bearer $HASS_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "$2" "${HASS_URL:-http://localhost:8123}$1" \
+    || echo "ha_call $1 failed"
+}
+
+last_conflict=""
+echo "git-sync started (interval ${INTERVAL}s, branch ${BRANCH})"
+
+while true; do
+  # 1. commit local drift (UI edits)
+  if [[ -n "$(git status --porcelain)" ]]; then
+    git add -A
+    git commit -q -m "chore(auto): sync changes made in Home Assistant" \
+      && echo "committed local changes"
+  fi
+
+  # 2. integrate remote
+  if git fetch -q origin "$BRANCH"; then
+    local_sha=$(git rev-parse HEAD)
+    remote_sha=$(git rev-parse "origin/$BRANCH")
+    applied=""
+    if [[ "$local_sha" != "$remote_sha" ]] \
+      && ! git merge-base --is-ancestor "origin/$BRANCH" HEAD; then
+      base=$(git merge-base HEAD "origin/$BRANCH")
+      if git rebase -q "origin/$BRANCH" > /dev/null; then
+        applied=$(git diff --name-only "$base" "$remote_sha")
+        echo "applied remote changes:"; echo "$applied"
+      else
+        git rebase --abort
+        if [[ "$last_conflict" != "$remote_sha" ]]; then
+          last_conflict="$remote_sha"
+          echo "rebase conflict on $remote_sha; manual fix needed"
+          ha_call /api/services/persistent_notification/create \
+            '{"title":"hass-config sync conflict","message":"git rebase failed in /config; resolve manually (kubectl exec)."}'
+        fi
+      fi
+    fi
+
+    # 3. push local commits (no-op when up to date)
+    git push -q origin "$BRANCH" 2>/dev/null || echo "push failed"
+
+    # 4. reload HA when remote changes were applied
+    if [[ -n "$applied" ]]; then
+      if echo "$applied" | grep -qE '^(configuration\.yaml|packages/)'; then
+        ha_call /api/services/persistent_notification/create \
+          '{"title":"hass-config synced","message":"configuration.yaml/packages changed via git; restart Home Assistant to apply."}'
+      else
+        ha_call /api/services/homeassistant/reload_all '{}'
+        echo "reload_all triggered"
+      fi
+    fi
+  else
+    echo "fetch failed; retrying in ${INTERVAL}s"
+  fi
+
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
Sidecar (same HA image) syncs /config with in-cluster Forgejo every
60s: commits+pushes UI edits (push mirror propagates to GitHub) and
rebases in remote pushes, then triggers reload_all via the HA API.
configuration.yaml/packages changes get a persistent notification
instead (those need a restart). Reload calls are skipped until a
HASS_TOKEN is added to the secret.

Token comes from the forgejo 1Password item (hass_sync_token,
write:repository scope). Script ConfigMap is substitute-disabled so
Flux postBuild leaves the bash ${VAR} expansions alone.

Part 4 of the Forgejo migration.

Signed-off-by: Dave Altena <dave@altena.io>
