### PR TITLE
feat(home-assistant): HASS_TOKEN voor git-sync auto-reload

### DIFF
--- a/kubernetes/apps/home-automation/home-assistant/app/externalsecret.yaml
+++ b/kubernetes/apps/home-automation/home-assistant/app/externalsecret.yaml
@@ -15,6 +15,7 @@ spec:
     template:
       data:
         FORGEJO_TOKEN: "{{ .forgejo_hass_sync_token }}"
+        HASS_TOKEN: "{{ .hass_api_token }}"
   dataFrom:
     - extract:
         key: forgejo
@@ -22,3 +23,9 @@ spec:
         - regexp:
             source: "(.*)"
             target: "forgejo_$1"
+    - extract:
+        key: homeassistant
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "hass_$1"


### PR DESCRIPTION
Long-lived access token (1P item homeassistant, veld api_token) in
het sync-secret; de sidecar kan nu reload_all en notificaties doen
na een remote pull.

Signed-off-by: Dave Altena <dave@altena.io>
