### PR TITLE
feat(bookboss): add BookBoss e-book library

### DIFF
--- a/kubernetes/apps/selfhosted/bookboss/app/externalsecret.yaml
+++ b/kubernetes/apps/selfhosted/bookboss/app/externalsecret.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: bookboss
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: bookboss-secret
+    creationPolicy: Owner
+    template:
+      data:
+        # BookBoss
+        BOOKBOSS__DATABASE__DATABASE_URL: "postgres://bookboss:{{ .bookboss_db_password }}@homelab-rw.databases.svc.cluster.local:5432/bookboss"
+        BOOKBOSS__ENCRYPTION_SECRET: "{{ .bookboss_encryption_secret }}"
+        BOOKBOSS__OIDC__CLIENT_SECRET: "{{ .bookboss_oauth_client_secret }}"
+        # Postgres Init
+        INIT_POSTGRES_DBNAME: bookboss
+        INIT_POSTGRES_HOST: homelab-rw.databases.svc.cluster.local
+        INIT_POSTGRES_USER: bookboss
+        INIT_POSTGRES_PASS: "{{ .bookboss_db_password }}"
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: bookboss
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "bookboss_$1"
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/selfhosted/bookboss/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/bookboss/app/helmrelease.yaml
@@ -1,0 +1,133 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: bookboss
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: bookboss
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    defaultPodOptions:
+      # Resolve externe namen (sso/metadata) direct i.p.v. via de search-suffixes
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+    controllers:
+      bookboss:
+        strategy: Recreate
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            runAsNonRoot: true
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/onedr0p/postgres-init
+              tag: 17.4
+              pullPolicy: IfNotPresent
+            envFrom:
+              - secretRef:
+                  name: bookboss-secret
+        containers:
+          app:
+            image:
+              repository: ghcr.io/szinn/bookboss
+              tag: v0.8.30@sha256:073a9e71fb731e624fe5d8f415df457685b5b3c66a613f610c3188a6c689a3db
+            env:
+              BOOKBOSS__FRONTEND__BASE_URL: "https://bookboss.${CLUSTER_DOMAIN}"
+              BOOKBOSS__LIBRARY__LIBRARY_PATH: "/library/books"
+              BOOKBOSS__IMPORT__BOOKDROP_PATH: "/library/bookdrop"
+              BOOKBOSS__OIDC__DISCOVERY_URL: "https://sso.${CLUSTER_DOMAIN}/realms/master/.well-known/openid-configuration"
+              BOOKBOSS__OIDC__CLIENT_ID: bookboss
+              BOOKBOSS__OIDC__BUTTON_LABEL: Keycloak
+              TZ: Europe/Amsterdam
+            envFrom:
+              - secretRef:
+                  name: bookboss-secret
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /healthz
+                    port: &port 8080
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /readyz
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+
+    service:
+      app:
+        controller: bookboss
+        ports:
+          http:
+            port: *port
+            primary: true
+
+    route:
+      app:
+        hostnames:
+          - "bookboss.${CLUSTER_DOMAIN}"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: bookboss
+                port: *port
+
+    persistence:
+      # VolSync-PVC (claim = app-naam); books + bookdrop als subPaths zodat
+      # de mappen gegarandeerd bestaan.
+      library:
+        existingClaim: bookboss
+        advancedMounts:
+          bookboss:
+            app:
+              - path: /library/books
+                subPath: books
+              - path: /library/bookdrop
+                subPath: bookdrop
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/selfhosted/bookboss/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/bookboss/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/selfhosted/bookboss/app/ocirepository.yaml
+++ b/kubernetes/apps/selfhosted/bookboss/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: bookboss
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/selfhosted/bookboss/ks.yaml
+++ b/kubernetes/apps/selfhosted/bookboss/ks.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &appname bookboss
+  namespace: flux-system
+spec:
+  targetNamespace: selfhosted
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *appname
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: external-secrets-stores
+    - name: volsync
+    - name: rook-ceph-cluster
+    - name: cnpg-cluster
+  interval: 30m
+  timeout: 5m
+  path: "./kubernetes/apps/selfhosted/bookboss/app"
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  postBuild:
+    substitute:
+      APP: *appname
+      APP_UID: "1000"
+      APP_GID: "1000"
+      VOLSYNC_CAPACITY: 25Gi
+      VOLSYNC_STORAGECLASS: ceph-block
+      VOLSYNC_SNAPSHOTCLASS: csi-ceph-blockpool

--- a/kubernetes/apps/selfhosted/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./namespace.yaml
   - ./actual-finance/ks.yaml
+  - ./bookboss/ks.yaml
   - ./forgejo/ks.yaml
   - ./mealie/ks.yaml
   - ./n8n/ks.yaml


### PR DESCRIPTION
szinn/bookboss (Rust e-book manager) in selfhosted, gebaseerd op
szinn's reference maar aangepast aan deze cluster:
- DB op CNPG homelab-cluster (postgres-init initContainer, db bookboss)
- library op nieuwe ceph-block PVC + VolSync (25Gi), books/bookdrop
  als subPaths
- web via envoy-internal (bookboss.${CLUSTER_DOMAIN})
- OIDC via Keycloak (master realm, confidential client + PKCE);
  creds + encryption secret via 1Password ExternalSecret
- gRPC-route weggelaten: envoy-internal heeft geen grpc-listener
  (alleen client-sync; web-UI werkt via https)

Keycloak-client 'bookboss' is via de admin-API aangemaakt (Keycloak
hier niet GitOps-beheerd) — enige out-of-band stuk.

Signed-off-by: Dave Altena <dave@altena.io>
