### PR TITLE
fix(observability): shrink Prometheus TSDB to cut disk-IO on slow Ceph

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -91,8 +91,8 @@ spec:
           - auto-gomemlimit
           - memory-snapshot-on-shutdown
           - new-service-discovery-manager
-        retention: 14d
-        retentionSize: 70GB
+        retention: 7d
+        retentionSize: 25GB
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
## Root cause
All the Pushover noise traces to **one** chain: Prometheus' TSDB (`retentionSize: 70GB`) lives on a `ceph-block` RBD backed by the slow **BX500 OSD (osd.2 on baldur)**. Compaction of the large TSDB saturates that disk:
- **NodeDiskIOSaturation** on `rbd3` (the Prometheus PVC, aqu-sq ~16)
- **PrometheusMissingRuleEvaluations** + **PrometheusRuleFailures** (Prometheus can't keep up → evals skipped/failed; no actually-broken rule)
- **CephHealthWarning** (osd.2 BlueStore slow-ops — the known BX500 issue, made worse by the IO storm)

## Fix
Shrink the TSDB to cut compaction IO: `retention 14d→7d`, `retentionSize 70GB→25GB`. Root-cause fix — clears the whole cascade, no symptom-silencing. Cost: ~7d metrics history instead of 14d.

Long-term this disappears entirely once the TSDB moves to the local SSD tier (Ceph→Synology migration).