### PR TITLE
feat(phobos): point Flux instance at main

### DIFF
--- a/kubernetes/clusters/phobos/apps/flux-system/flux-operator/instance/helm-values.yaml
+++ b/kubernetes/clusters/phobos/apps/flux-system/flux-operator/instance/helm-values.yaml
@@ -14,7 +14,7 @@ instance:
   sync:
     kind: GitRepository
     url: https://github.com/davealtena/homelab
-    ref: refs/heads/feat/phobos
+    ref: refs/heads/main
     path: kubernetes/clusters/phobos/flux
   kustomize:
     patches:


### PR DESCRIPTION
Migration is merged; switch the phobos Flux instance sync ref from `feat/phobos` to `main`. After this merges, feat/phobos will be deleted.