### PR TITLE
fix: recover unifi-network-mcp crashloop + restore mise KUBECONFIG

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,2 +1,3 @@
 [env]
 KUBERNETES_DIR = '{{config_root}}/kubernetes'
+KUBECONFIG = '{{config_root}}/kubernetes/kubeconfig'

--- a/kubernetes/clusters/phobos/apps/ai/toolhive/config/app/unifi-mcp.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/toolhive/config/app/unifi-mcp.yaml
@@ -4,7 +4,7 @@ kind: MCPServer
 metadata:
   name: unifi-network-mcp
 spec:
-  image: ghcr.io/sirkirby/unifi-network-mcp:sha-b716164
+  image: ghcr.io/sirkirby/unifi-network-mcp:sha-608aceb
   transport: stdio
   proxyMode: streamable-http
   proxyPort: 8080


### PR DESCRIPTION
## Wat & waarom

Twee onafhankelijke fixes:

### 1. `fix(container)`: bump `unifi-network-mcp` → `sha-608aceb` (v0.24.1)
De MCPServer `unifi-network-mcp` in `ai` zat in een crash-loop (~500 restarts sinds 29 jul), goed voor 4 open Alertmanager-alerts (`KubePodCrashLooping`, `KubePodNotReady`, `KubeDeploymentReplicasMismatch`).

**Root cause:** de pinned image `sha-b716164` stamt uit **april 2025**, van vóór MCP-protocolonderhandeling. Na de `toolhive-operator` 0.41.0-bump (#1932) stuurt de proxy een `server/discover`-probe die de oude server niet kan parsen → hij exit → crash-loop. De 4 andere MCP-servers draaien wél op 0.41.0.

**Fix:** `sha-608aceb` is de v0.24.1 release-build (jul 2026) op FastMCP met correcte protocol-negotiation. Live gevalideerd: pod start schoon, registreert alle ~40 tools, MCPServer meldt `Ready`, 0 restarts. Bestaand env/secret-schema (`UNIFI_HOST/USERNAME/PASSWORD`) blijft geldig.

> Los hiervan is de gestalde `toolhive-operator` HelmRelease (dezelfde 0.41.0-upgrade timede out tijdens de rollout) apart met een force-reconcile hersteld — geen config-wijziging nodig, dus niet in deze PR.

### 2. `fix(mise)`: herstel automatische `KUBECONFIG`-export
De `KUBECONFIG`-regel in `.mise.toml` was in #1838 verwijderd als "stale config", maar `kubernetes/kubeconfig` is nog in gebruik. Teruggezet zodat mise 'm weer automatisch exporteert bij binnenkomen van de repo-dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)