### PR TITLE
feat(ai): bridge ToolHive VirtualMCPServer into LiteLLM

### DIFF
--- a/kubernetes/clusters/phobos/apps/ai/litellm/app/kustomization.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/litellm/app/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - ./cache.yaml
   - ./job-init-db.yaml
   - ./litellmproxy.yaml
+  - ./mcpserver-toolhive.yaml
   - ./models/

--- a/kubernetes/clusters/phobos/apps/ai/litellm/app/mcpserver-toolhive.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/litellm/app/mcpserver-toolhive.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmcpserver_v1alpha1.json
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMMCPServer
+metadata:
+  name: toolhive
+spec:
+  # Exposes the ToolHive VirtualMCPServer (which aggregates the kubectl/github/
+  # garmin/hass/unifi MCP servers) as a single MCP endpoint on the LiteLLM
+  # gateway, so any OpenAI-compatible client of litellm gets the tools.
+  # ToolHive stays the hosting/isolation/aggregation layer; litellm only exposes
+  # its aggregated endpoint. The VirtualMCPServer uses anonymous incoming auth,
+  # so no auth is configured here.
+  alias: toolhive
+  url: http://vmcp-mcp-gateway-internal.ai.svc.cluster.local:4483/mcp
+  transport: http


### PR DESCRIPTION
## What

Registers the ToolHive `VirtualMCPServer` (`mcp-gateway-internal`) as a single `LiteLLMMCPServer` on the litellm proxy, at `http://vmcp-mcp-gateway-internal.ai.svc.cluster.local:4483/mcp`.

## Why

Completes the "keep ToolHive + bridge" architecture:

- **ToolHive** stays the MCP hosting/isolation/aggregation layer — it runs the kubectl/github/garmin/hass/unifi MCP servers as isolated workloads and aggregates them behind one endpoint.
- **LiteLLM** exposes that single aggregated endpoint, so any OpenAI-compatible client of the gateway (open-webui, agents) gets all the tools — without LiteLLM having to know about the individual servers.

No auth is configured on the litellm side because the `VirtualMCPServer` uses `incomingAuth: anonymous`.

## Notes

- Endpoint DNS/port verified against the ToolHive operator source: service `vmcp-<name>`, `vmcpDefaultPort = 4483`, MCP path `/mcp`, transport `http` (streamable-http).
- Soft runtime dependency on ToolHive being up — that's fine; the CR only adds a URL to litellm's rendered config.
- Depends on #1959 (litellm-operator, already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)