### PR TITLE
feat(ai): add open-webui chat UI (litellm + ToolHive MCP)

### DIFF
--- a/kubernetes/clusters/phobos/apps/ai/open-webui/app/externalsecret.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/open-webui/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: open-webui
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: open-webui
+    creationPolicy: Owner
+    template:
+      data:
+        # Open WebUI talks to the litellm gateway as an OpenAI-compatible
+        # backend; the litellm master key is its API key.
+        OPENAI_API_KEY: "{{ .master_key }}"
+  dataFrom:
+    - extract:
+        key: litellm

--- a/kubernetes/clusters/phobos/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/open-webui/app/helmrelease.yaml
@@ -1,0 +1,71 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: open-webui
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: open-webui
+  interval: 30m
+  values:
+    controllers:
+      open-webui:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/open-webui/open-webui
+              tag: v0.11.0
+            env:
+              # Models come exclusively from the litellm gateway (OpenAI-compatible).
+              ENABLE_OLLAMA_API: false
+              ENABLE_OPENAI_API: true
+              OPENAI_API_BASE_URL: http://litellm.ai.svc.cluster.local:4000/v1
+              WEBUI_URL: https://chat.${CLUSTER_DOMAIN}
+              # First visit → sign up to create the admin account. Flip to false
+              # afterwards (VPN-only, single user) if you want to lock it down.
+              ENABLE_SIGNUP: true
+              # Native MCP tool server: point Open WebUI straight at the ToolHive
+              # VirtualMCPServer (aggregates garmin/home-assistant/unifi/kubectl/
+              # github). Streamable-HTTP is natively supported since v0.6.31 — no
+              # mcpo, no routing tools through litellm. Anonymous in-cluster auth.
+              # Seeds the DB on first boot (PersistentConfig); manage later in the
+              # admin UI (Admin Settings → External Tools).
+              TOOL_SERVER_CONNECTIONS: >-
+                [{"type":"mcp","url":"http://vmcp-mcp-gateway-internal.ai.svc.cluster.local:4483/mcp","path":"","auth_type":"none","config":{"enable":true},"info":{"id":"toolhive-vmcp","name":"ToolHive VMCP","description":"garmin, home-assistant, unifi, kubectl, github"}}]
+            envFrom:
+              - secretRef:
+                  name: open-webui
+            resources:
+              requests:
+                cpu: 100m
+              limits:
+                memory: 2Gi
+
+    persistence:
+      config:
+        existingClaim: open-webui
+        globalMounts:
+          - path: /app/backend/data
+
+    route:
+      app:
+        hostnames:
+          - chat.${CLUSTER_DOMAIN}
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - identifier: app
+                port: 8080
+
+    service:
+      app:
+        ports:
+          http:
+            port: 8080

--- a/kubernetes/clusters/phobos/apps/ai/open-webui/app/kustomization.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/open-webui/app/kustomization.yaml
@@ -3,8 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./litellm-operator/ks.yaml
-  - ./litellm/ks.yaml
-  - ./open-webui/ks.yaml
-  - ./toolhive/ks.yaml
+  - ./externalsecret.yaml
+  - ./pvc.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/clusters/phobos/apps/ai/open-webui/app/ocirepository.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/open-webui/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: open-webui
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/clusters/phobos/apps/ai/open-webui/app/pvc.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/open-webui/app/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: open-webui
+spec:
+  accessModes: ["ReadWriteOnce"]
+  # Local NVMe: Open WebUI stores its state in a SQLite DB, which is unreliable
+  # over NFS (file locking). Keep it on local-hostpath instead of nfs-csi-sc.
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/clusters/phobos/apps/ai/open-webui/ks.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/open-webui/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app open-webui
+  namespace: flux-system
+spec:
+  targetNamespace: ai
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+    - name: litellm
+  path: ./kubernetes/clusters/phobos/apps/ai/open-webui/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## What

Adds **Open WebUI** — a self-hosted chat / AI-engineering front-end — as the replacement for the ad-hoc "Hermes" agent, at `chat.${CLUSTER_DOMAIN}` (envoy-internal).

## How it's wired

- **Models** come exclusively from the **litellm** gateway (`OPENAI_API_BASE_URL=http://litellm.ai.svc.cluster.local:4000/v1`, key = litellm master key via ExternalSecret). Ollama + direct-OpenAI disabled.
- **Tools** — native MCP tool server pointed **directly** at the ToolHive `VirtualMCPServer` (`http://vmcp-mcp-gateway-internal.ai.svc.cluster.local:4483/mcp`), which aggregates the garmin/home-assistant/unifi/kubectl/github MCP servers. Open WebUI has spoken native MCP over streamable-HTTP since **v0.6.31**, so **no mcpo** and **no routing tools through litellm** (that path is still WIP upstream — open-webui#15177). The model does the tool-calling; pick a function-calling model (gpt-4.1 / minimax).
- **Storage** — SQLite state on local NVMe (`openebs-hostpath`); NFS is unreliable for SQLite file locking.

## Notes

- First visit → sign up to create the admin account (`ENABLE_SIGNUP: true`). VPN-only + single user; flip to `false` afterwards to lock it down. No external OIDC (bjw-s uses Kanidm; not applicable here).
- `TOOL_SERVER_CONNECTIONS` is PersistentConfig — it **seeds the DB on first boot**; manage the tool server afterwards in Admin Settings → External Tools. `WEBUI_SECRET_KEY` is auto-generated and persisted on the PVC (MCP auth is `none`, so nothing sensitive to re-encrypt).
- Soft runtime dependency on ToolHive being up — expected, not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)