### PR TITLE
fix(ai): pin litellm-operator to 0.0.9 (0.0.10 RBAC regression)

### DIFF
--- a/kubernetes/clusters/phobos/apps/ai/litellm-operator/app/ocirepository.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/litellm-operator/app/ocirepository.yaml
@@ -9,6 +9,7 @@ spec:
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
+  # Held at 0.0.9: 0.0.10 crash-loops (missing RBAC for its new CRDs).
   ref:
-    tag: 0.0.10
+    tag: 0.0.9
   url: oci://ghcr.io/home-operations/charts/litellm-operator


### PR DESCRIPTION
## Problem

After #1959 the `litellm-operator` pod crash-loops:

```
problem running manager: failed to wait for litellmvirtualkey caches to sync
... litellmteams.litellm.home-operations.com is forbidden: User
"system:serviceaccount:ai:litellm-operator" cannot list resource "litellmteams"
```

Chart **0.0.10** compiles in the `LiteLLMTeam` / `LiteLLMVirtualKey` controllers, but its `ClusterRole` only grants `litellmproxies/litellmmodels/litellmguardrails/litellmmcpservers` — no RBAC for the new CRDs. The manager can't sync those caches → times out → exits.

## Fix

Pin to **0.0.9**, the version bjw-s-labs runs, which doesn't have the gap. Held there (with a comment) until upstream fixes the RBAC in a later release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)