### PR TITLE
fix(ai): unifi-network-mcp uses streamable-http, not stdio

### DIFF
--- a/kubernetes/clusters/phobos/apps/ai/toolhive/config/app/unifi-mcp.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/toolhive/config/app/unifi-mcp.yaml
@@ -5,9 +5,11 @@ metadata:
   name: unifi-network-mcp
 spec:
   image: ghcr.io/sirkirby/unifi-network-mcp:sha-608aceb
-  transport: stdio
+  # The image serves streamable-http on :3000, not stdio.
+  transport: streamable-http
   proxyMode: streamable-http
   proxyPort: 8080
+  mcpPort: 3000
   env:
     # The image's entrypoint runs /app/src/main.py without /app on the path,
     # so `import src...` fails (ModuleNotFoundError). Put /app on PYTHONPATH.


### PR DESCRIPTION
## Problem

Enabling the ToolHive tools in Open WebUI failed with **"Failed to connect to MCP server 'toolhive-vmcp'"**.

Root cause: the `sirkirby/unifi-network-mcp` image serves **streamable-http on :3000** (its logs: *"Starting FastMCP Streamable HTTP server on 0.0.0.0:3000"* — it even connects to the UniFi controller fine), but the `MCPServer` declared `transport: stdio`. ToolHive's proxy tried to speak stdio to an HTTP server, so the MCP `initialize` handshake never completed → backend marked unhealthy → the `VirtualMCPServer` aggregate **hangs for 30s and returns nothing** on every client initialize. A healthy backend (hass) responds in ~3ms; the vmcp gateway returned `http=000` after 30s.

## Fix

`transport: streamable-http` + `mcpPort: 3000` so the proxy forwards to the image's native HTTP server.

The other 4 backends (garmin/hass/github/kubectl, ~430 tools) already aggregate fine; this unblocks the whole endpoint for Open WebUI.

## Follow-up (not in this PR)

There's an orphaned `StatefulSet/unifi-network-mcp` (no ownerRef, leftover from an older ToolHive that used StatefulSets) running a duplicate copy — will be cleaned up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)