### PR TITLE
feat(ai): add Ollama for local GPU inference

### DIFF
--- a/kubernetes/clusters/phobos/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/ollama/app/helmrelease.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ollama
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: ollama
+  interval: 30m
+  values:
+    defaultPodOptions:
+      runtimeClassName: nvidia-cdi
+    controllers:
+      ollama:
+        containers:
+          app:
+            image:
+              repository: docker.io/ollama/ollama
+              tag: 0.32.5
+            env:
+              OLLAMA_HOST: 0.0.0.0
+              OLLAMA_KEEP_ALIVE: "24h"
+            lifecycle:
+              postStart:
+                exec:
+                  command:
+                    - /bin/sh
+                    - -c
+                    - until ollama list >/dev/null 2>&1; do sleep 2; done; ollama pull nomic-embed-text || true
+            resources:
+              requests:
+                cpu: 200m
+                memory: 1Gi
+              limits:
+                nvidia.com/gpu: 1
+                memory: 8Gi
+    service:
+      app:
+        ports:
+          http:
+            port: 11434
+    persistence:
+      models:
+        existingClaim: ollama
+        globalMounts:
+          - path: /root/.ollama

--- a/kubernetes/clusters/phobos/apps/ai/ollama/app/kustomization.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/ollama/app/kustomization.yaml
@@ -3,9 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./litellm-operator/ks.yaml
-  - ./litellm/ks.yaml
-  - ./ollama/ks.yaml
-  - ./open-webui/ks.yaml
-  - ./toolhive/ks.yaml
+  - ./pvc.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/clusters/phobos/apps/ai/ollama/app/ocirepository.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/ollama/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: ollama
+spec:
+  interval: 10m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/clusters/phobos/apps/ai/ollama/app/pvc.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/ollama/app/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ollama
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 50Gi

--- a/kubernetes/clusters/phobos/apps/ai/ollama/ks.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/ollama/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app ollama
+  namespace: flux-system
+spec:
+  targetNamespace: ai
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/clusters/phobos/apps/ai/ollama/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
## What

Adds **Ollama** for local inference on the node's **NVIDIA RTX 5060 Ti**, primarily to serve as memini's embeddings backend (the next step).

## Details

- GPU via the documented consumer pattern: `runtimeClassName: nvidia-cdi` + `resources.limits.nvidia.com/gpu: 1`.
- Models on **local NVMe** (`openebs-hostpath`, 50Gi) at `/root/.ollama`.
- A `postStart` hook waits for the server, then `ollama pull nomic-embed-text` so the embedding model is present without manual steps.
- OpenAI-compatible API on `:11434` (ClusterIP, internal only).

## Next

memini will point its embeddings at this (directly or via a litellm model). Local chat models can be pulled later and surfaced in Open WebUI through litellm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)