### PR TITLE
feat(ai): add memini LLM memory (Ollama bge-m3 embeddings)

### DIFF
--- a/kubernetes/clusters/phobos/apps/ai/kustomization.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./namespace.yaml
   - ./litellm-operator/ks.yaml
   - ./litellm/ks.yaml
+  - ./memini/ks.yaml
   - ./ollama/ks.yaml
   - ./open-webui/ks.yaml
   - ./toolhive/ks.yaml

--- a/kubernetes/clusters/phobos/apps/ai/memini/app/externalsecret.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/memini/app/externalsecret.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: memini
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: memini-secret
+    creationPolicy: Owner
+    template:
+      data:
+        MEMINI_API_KEY: "{{ .memini_api_key }}"
+        LITELLM_API_KEY: "{{ .litellm_master_key }}"
+  dataFrom:
+    - extract:
+        key: memini
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "memini_$1"
+    - extract:
+        key: litellm
+      rewrite:
+        - regexp:
+            source: "(.*)"
+            target: "litellm_$1"

--- a/kubernetes/clusters/phobos/apps/ai/memini/app/helmrelease.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/memini/app/helmrelease.yaml
@@ -1,0 +1,94 @@
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: memini
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: memini
+  interval: 30m
+  values:
+    controllers:
+      main:
+        type: deployment
+        replicas: 1
+        annotations:
+          reloader.stakater.com/auto: "true"
+        pod:
+          securityContext:
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+            runAsGroup: 1000
+            runAsNonRoot: true
+            runAsUser: 1000
+        containers:
+          main:
+            env:
+              MEMINI_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: memini-secret
+                    key: MEMINI_API_KEY
+              MEMINI_BACKEND: sqlite
+              MEMINI_DEFAULT_NAMESPACE: default
+              MEMINI_DEDUP_SIMILARITY: "0.80"
+              MEMINI_SHORT_TERM_CAP: "300"
+              MEMINI_DEMOTE_AFTER: 1440h
+              MEMINI_EMBED_BASE_URL: http://ollama.ai.svc.cluster.local:11434/v1
+              MEMINI_EMBED_MODEL: bge-m3
+              MEMINI_EMBED_DIMS: "1024"
+              MEMINI_EMBED_MAX_CONCURRENCY: "2"
+              MEMINI_LOG_FORMAT: json
+              MEMINI_LLM_API: openai
+              MEMINI_LLM_BASE_URL: http://litellm.ai.svc.cluster.local:4000/v1
+              MEMINI_LLM_MODEL: gpt-4.1-mini
+              MEMINI_LLM_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: memini-secret
+                    key: LITELLM_API_KEY
+              MEMINI_RECALL_EMBED_TIMEOUT: "10s"
+              MEMINI_TOMBSTONE_TTL: 720h
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+      fsck:
+        enabled: true
+        cronjob:
+          schedule: "0 5 * * *"
+        containers:
+          fsck:
+            env:
+              MEMINI_API_KEY:
+                valueFrom:
+                  secretKeyRef:
+                    name: memini-secret
+                    key: MEMINI_API_KEY
+    persistence:
+      data:
+        existingClaim: memini
+    route:
+      ui:
+        enabled: true
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        hostnames:
+          - memini.${CLUSTER_DOMAIN}
+    serviceMonitor:
+      main:
+        enabled: false
+    grafanaDashboards:
+      enabled: false

--- a/kubernetes/clusters/phobos/apps/ai/memini/app/kustomization.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/memini/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./pvc.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/clusters/phobos/apps/ai/memini/app/ocirepository.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/memini/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: memini
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: v0.7.17
+  url: oci://registry.erwanleboucher.dev/eleboucher/charts/memini

--- a/kubernetes/clusters/phobos/apps/ai/memini/app/pvc.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/memini/app/pvc.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: memini
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: openebs-hostpath
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/clusters/phobos/apps/ai/memini/ks.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/memini/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app memini
+  namespace: flux-system
+spec:
+  targetNamespace: ai
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+    - name: litellm
+    - name: ollama
+  path: ./kubernetes/clusters/phobos/apps/ai/memini/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m

--- a/kubernetes/clusters/phobos/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/ollama/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
                   command:
                     - /bin/sh
                     - -c
-                    - until ollama list >/dev/null 2>&1; do sleep 2; done; ollama pull nomic-embed-text || true
+                    - until ollama list >/dev/null 2>&1; do sleep 2; done; ollama pull bge-m3 || true
             resources:
               requests:
                 cpu: 200m


### PR DESCRIPTION
## What

Adds **memini** — an LLM long-term/short-term memory service — plus wires its embeddings to the new local **Ollama**.

## Wiring

- **Embeddings** → local Ollama at `http://ollama.ai.svc.cluster.local:11434/v1`, model **`bge-m3`** (1024-dim, multilingual — good for Dutch — and needs no query/document prefix, unlike nomic). This PR also flips Ollama's preloaded model from `nomic-embed-text` to `bge-m3`.
- **LLM** → litellm (`gpt-4.1-mini`) for memory extraction/dedup.
- **Storage** → SQLite on local NVMe (`openebs-hostpath`).
- Nightly `fsck` CronJob (05:00); route `memini.${CLUSTER_DOMAIN}` on envoy-internal.
- `serviceMonitor`/`grafanaDashboards` disabled for now (can enable later).

## Secrets

`ExternalSecret` pulls `MEMINI_API_KEY` from a new 1Password `memini` item and reuses the litellm master key as `LITELLM_API_KEY` (both from the Homelab vault via the `onepassword` store).

## Depends on

litellm + ollama (Flux `dependsOn`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)