### PR TITLE
fix(ai): run unifi-network-mcp as stdio via uvx

### DIFF
--- a/kubernetes/clusters/phobos/apps/ai/toolhive/config/app/unifi-mcp.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/toolhive/config/app/unifi-mcp.yaml
@@ -4,24 +4,23 @@ kind: MCPServer
 metadata:
   name: unifi-network-mcp
 spec:
-  image: ghcr.io/sirkirby/unifi-network-mcp:sha-608aceb
-  # The image serves streamable-http on :3000, not stdio.
-  transport: streamable-http
+  # Run the published stdio server via uvx (the Docker image serves HTTP and
+  # trips the MCP SDK's Host-header/DNS-rebinding check behind ToolHive's proxy).
+  image: ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+  transport: stdio
   proxyMode: streamable-http
   proxyPort: 8080
-  mcpPort: 3000
   env:
-    # The image's entrypoint runs /app/src/main.py without /app on the path,
-    # so `import src...` fails (ModuleNotFoundError). Put /app on PYTHONPATH.
-    - name: PYTHONPATH
-      value: /app
+    - name: HOME
+      value: /tmp
+    - name: UV_CACHE_DIR
+      value: /tmp/.uv-cache
     - name: UNIFI_HOST
       value: "192.168.1.1"
     - name: UNIFI_PORT
       value: "443"
     - name: UNIFI_SITE
       value: default
-    # UniFi controller uses a self-signed cert
     - name: UNIFI_VERIFY_SSL
       value: "false"
   secrets:
@@ -32,8 +31,24 @@ spec:
   resources:
     requests:
       cpu: 50m
-      memory: 128Mi
+      memory: 256Mi
     limits:
-      memory: 384Mi
+      memory: 768Mi
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          image: ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - uvx unifi-network-mcp@0.25.1
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
   groupRef:
     name: mcp-tools


### PR DESCRIPTION
## Problem

unifi's tools never appear in Open WebUI because the VMCP marks the backend `unavailable`. The `ghcr.io/sirkirby/unifi-network-mcp` Docker image serves **streamable-http** on :3000, and the MCP SDK's DNS-rebinding protection rejects ToolHive's proxied request:

```
mcp.server.transport_security - WARNING - Invalid Host header: mcp-unifi-network-mcp:3000
POST /mcp HTTP/1.1" 421 Misdirected Request
```

So the MCP `initialize` never succeeds and the backend stays down (39+ failures).

## Fix

Run the **published stdio server via uvx** instead of the HTTP Docker image — the canonical way the project documents it (`uvx unifi-network-mcp`). ToolHive attaches over stdio, so there's no HTTP server and no Host-header validation. Same pattern as `home-assistant-mcp` (uv image + `uvx ...` + `transport: stdio`).

- Image `ghcr.io/astral-sh/uv:python3.13-bookworm-slim` (glibc → manylinux wheels for aiohttp/pydantic; server requires Python ≥3.13).
- `uvx unifi-network-mcp@0.25.1` (pinned).
- Keeps existing `UNIFI_HOST`/site/SSL env + the `toolhive-unifi-*` username/password secrets.

Once the backend is healthy, its tools join the VMCP aggregate and show up in Open WebUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)