### PR TITLE
feat(observability): source grafana admin creds from 1Password

### DIFF
--- a/kubernetes/clusters/phobos/apps/observability/grafana-operator/instance/externalsecret.yaml
+++ b/kubernetes/clusters/phobos/apps/observability/grafana-operator/instance/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-admin-credentials
+spec:
+  refreshInterval: 12h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: grafana-admin-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: GF_SECURITY_ADMIN_USER
+      remoteRef:
+        key: grafana
+        property: username
+    - secretKey: GF_SECURITY_ADMIN_PASSWORD
+      remoteRef:
+        key: grafana
+        property: password

--- a/kubernetes/clusters/phobos/apps/observability/grafana-operator/instance/kustomization.yaml
+++ b/kubernetes/clusters/phobos/apps/observability/grafana-operator/instance/kustomization.yaml
@@ -4,6 +4,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: observability
 resources:
+  - ./externalsecret.yaml
   - ./grafana.yaml
   - ./grafanadatasource.yaml
   - ./servicemonitor.yaml


### PR DESCRIPTION
## Problem

The Grafana admin login (from 1Password) didn't work. Root cause: `grafana-admin-credentials` was created out-of-band at bootstrap and **never wired to 1Password** — no ExternalSecret. The 1Password `grafana` item drifted (held stale passwords), so what you typed returned 401. Only the in-cluster secret value actually worked.

## Fix

Add an `ExternalSecret` (in the grafana-operator instance) that sources `grafana-admin-credentials` (`GF_SECURITY_ADMIN_USER` + `GF_SECURITY_ADMIN_PASSWORD`) from the Homelab `grafana` item via the `onepassword` store. 1Password becomes the source of truth, in Git, and rotatable.

Note: the 1Password item was cleaned up (canonical `username`/`password`, dropped duplicate fields) and, because Grafana persists its admin password in its DB (env only applies at first init), the DB admin password is reset to match out-of-band after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)