### PR TITLE
feat(observability): grafana BYO admin secret from 1Password

### DIFF
--- a/kubernetes/clusters/phobos/apps/observability/grafana-operator/instance/grafana.yaml
+++ b/kubernetes/clusters/phobos/apps/observability/grafana-operator/instance/grafana.yaml
@@ -49,6 +49,11 @@ spec:
               env:
                 - name: GF_INSTALL_PLUGINS
                   value: "grafana-clock-panel,grafana-piechart-panel,grafana-worldmap-panel,natel-discrete-panel,pr0ps-trackmap-panel,vonage-status-panel"
+                - name: GF_SECURITY_ADMIN_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-admin-credentials
+                      key: GF_SECURITY_ADMIN_USER
                 - name: GF_SECURITY_ADMIN_PASSWORD
                   valueFrom:
                     secretKeyRef:
@@ -90,4 +95,7 @@ spec:
         requests:
           storage: 10Gi
       storageClassName: openebs-hostpath
+  # Admin creds come from 1Password via the grafana-admin-credentials
+  # ExternalSecret; stop the operator from generating its own.
+  disableDefaultAdminSecret: true
   disableDefaultSecurityContext: All


### PR DESCRIPTION
## Context

Follow-up to #1967. That ExternalSecret couldn't take ownership of `grafana-admin-credentials` because **grafana-operator generates and owns it** (`disableDefaultAdminSecret` defaults false) and live-syncs the running admin password from it.

## Fix

Set `disableDefaultAdminSecret: true` so the operator stops generating the secret, letting the ExternalSecret own it (sourced from the Homelab `grafana` 1Password item). Add `GF_SECURITY_ADMIN_USER` env alongside the existing password.

Result chain: **1Password → ExternalSecret → `grafana-admin-credentials` → Grafana**. 1Password is now the source of truth, in Git, rotatable.

Post-merge (out of band): delete the operator-owned secret so ESO recreates it, then restart Grafana so it picks up the 1Password password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)