### PR TITLE
feat(ai): litellm observability — prometheus + Grafana dashboard

### DIFF
--- a/kubernetes/clusters/phobos/apps/ai/litellm/app/kustomization.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/litellm/app/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - ./job-init-db.yaml
   - ./litellmproxy.yaml
   - ./mcpserver-toolhive.yaml
+  - ./servicemonitor.yaml
   - ./models/

--- a/kubernetes/clusters/phobos/apps/ai/litellm/app/litellmproxy.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/litellm/app/litellmproxy.yaml
@@ -17,6 +17,8 @@ spec:
     num_retries: 2
   litellmSettings:
     drop_params: true
+    success_callback:
+      - prometheus
     cache: true
     cache_params:
       type: redis

--- a/kubernetes/clusters/phobos/apps/ai/litellm/app/servicemonitor.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/litellm/app/servicemonitor.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: litellm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: litellm
+  namespaceSelector:
+    matchNames:
+      - ai
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+      bearerTokenSecret:
+        name: litellm
+        key: LITELLM_MASTER_KEY

--- a/kubernetes/clusters/phobos/apps/observability/grafana-operator/dashboards/kustomization.yaml
+++ b/kubernetes/clusters/phobos/apps/observability/grafana-operator/dashboards/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: observability
 resources:
   - ./grafanadashboard.yaml
+  - ./litellm.yaml
   - ./kubernetes.yaml
   - ./node-prometheus.yaml
   - ./networking.yaml

--- a/kubernetes/clusters/phobos/apps/observability/grafana-operator/dashboards/litellm.yaml
+++ b/kubernetes/clusters/phobos/apps/observability/grafana-operator/dashboards/litellm.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: litellm
+spec:
+  instanceSelector:
+    matchLabels:
+      grafana.internal/instance: grafana
+  url: https://raw.githubusercontent.com/BerriAI/litellm/main/cookbook/litellm_proxy_server/grafana_dashboard/dashboard_v2/grafana_dashboard.json
+  datasources:
+    - inputName: DS_PROMETHEUS
+      datasourceName: Prometheus


### PR DESCRIPTION
## What

The first observability layer for the LLM gateway (no Langfuse, using the existing kube-prometheus-stack + Grafana):

- **Enable litellm prometheus metrics** — `litellmSettings.success_callback: [prometheus]`, which exposes `/metrics`.
- **ServiceMonitor** scraping the litellm service (`port: http`, `path: /metrics`, 30s), authenticated with the master key (`bearerTokenSecret` → `litellm`/`LITELLM_MASTER_KEY`). Prometheus already selects all ServiceMonitors cluster-wide.
- **Grafana dashboard** — the upstream *LiteLLM Prod v2* dashboard via a `GrafanaDashboard` CR (grafana-operator), mapped to the Prometheus datasource.

Gives you request rate / latency / tokens / spend per model in Grafana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)