### PR TITLE
fix(ai): litellm metrics path /metrics/

### DIFF
--- a/kubernetes/clusters/phobos/apps/ai/litellm/app/servicemonitor.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/litellm/app/servicemonitor.yaml
@@ -13,7 +13,7 @@ spec:
       - ai
   endpoints:
     - port: http
-      path: /metrics
+      path: /metrics/
       interval: 30s
       scrapeTimeout: 10s
       bearerTokenSecret:


### PR DESCRIPTION
`/metrics` returns a 307 redirect to `/metrics/`; point the ServiceMonitor at the canonical path so Prometheus scrapes a direct 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)