### PR TITLE
fix(ai): keep bge-m3 warm for memini embeddings

### DIFF
--- a/kubernetes/clusters/phobos/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/clusters/phobos/apps/ai/ollama/app/helmrelease.yaml
@@ -21,14 +21,15 @@ spec:
               tag: 0.32.5
             env:
               OLLAMA_HOST: 0.0.0.0
-              OLLAMA_KEEP_ALIVE: "24h"
+              # Keep models resident so memini's embeddings never cold-start.
+              OLLAMA_KEEP_ALIVE: "-1"
             lifecycle:
               postStart:
                 exec:
                   command:
                     - /bin/sh
                     - -c
-                    - until ollama list >/dev/null 2>&1; do sleep 2; done; ollama pull bge-m3 || true
+                    - until ollama list >/dev/null 2>&1; do sleep 2; done; ollama pull bge-m3 && ollama run bge-m3 warmup >/dev/null 2>&1 || true
             resources:
               requests:
                 cpu: 200m


### PR DESCRIPTION
Cold-loading bge-m3 takes ~7s — longer than memini's startup embed check (~3s) — so memini degraded to keyword-only. Warm the model at Ollama startup (`ollama run bge-m3`, no curl in the image) and pin it in VRAM (`OLLAMA_KEEP_ALIVE=-1`) so embeddings are always warm.

Verified: with bge-m3 warm, memini restarts without the 'embeddings unreachable' warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)