### PR TITLE
fix(ai): hold litellm-operator at 0.0.9 + block Renovate bump

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -20,6 +20,16 @@
     },
     {
       "description": [
+        "Hold litellm-operator at 0.0.9: the 0.0.10/0.0.11 chart ClusterRole",
+        "omits RBAC for its new LiteLLMTeam/VirtualKey CRDs, so the manager",
+        "crash-loops. Remove this rule once upstream fixes the chart RBAC."
+      ],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["ghcr.io/home-operations/charts/litellm-operator"],
+      "enabled": false
+    },
+    {
+      "description": [
         "Cluster-critical charts: a semver-MINOR here can be breaking (e.g. a",
         "Cilium CSI/RBAC change). Don't auto-merge their minors — request review",
         "+ label so I approve in a maintenance window."

--- a/kubernetes/apps/ai/litellm-operator/app/ocirepository.yaml
+++ b/kubernetes/apps/ai/litellm-operator/app/ocirepository.yaml
@@ -9,7 +9,7 @@ spec:
   layerSelector:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
-  # Held at 0.0.9: 0.0.10 crash-loops (missing RBAC for its new CRDs).
+  # Held at 0.0.9 (Renovate hold): 0.0.10+ chart RBAC omits its new CRDs -> crash-loop.
   ref:
-    tag: 0.0.10
+    tag: 0.0.9
   url: oci://ghcr.io/home-operations/charts/litellm-operator


### PR DESCRIPTION
Renovate auto-merged 0.0.10 overnight (#1975), bringing back the crash-loop (0.0.10/0.0.11 chart ClusterRole lacks RBAC for its LiteLLMTeam/VirtualKey CRDs → manager cache-sync timeout → CrashLoopBackOff, 38 restarts).

- Re-pin OCIRepository tag to `0.0.9`.
- Add a Renovate `packageRule` (`enabled: false`) for `ghcr.io/home-operations/charts/litellm-operator` so it can't silently bump again. Remove once upstream fixes the chart RBAC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)