### PR TITLE
feat(ai): wire memini env into open-webui

### DIFF
--- a/kubernetes/apps/ai/open-webui/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/open-webui/app/externalsecret.yaml
@@ -12,11 +12,14 @@ spec:
   target:
     name: open-webui
     creationPolicy: Owner
-    template:
-      data:
-        # Open WebUI talks to the litellm gateway as an OpenAI-compatible
-        # backend; the litellm master key is its API key.
-        OPENAI_API_KEY: "{{ .master_key }}"
-  dataFrom:
-    - extract:
+  data:
+    # OpenAI-compatible backend = the litellm gateway (master key).
+    - secretKey: OPENAI_API_KEY
+      remoteRef:
         key: litellm
+        property: master_key
+    # Consumed by the memini memory filter function (Admin -> Functions).
+    - secretKey: MEMINI_API_KEY
+      remoteRef:
+        key: memini
+        property: api_key

--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -25,6 +25,9 @@ spec:
               ENABLE_OPENAI_API: true
               OPENAI_API_BASE_URL: http://litellm.ai.svc.cluster.local:4000/v1
               WEBUI_URL: https://chat.${CLUSTER_DOMAIN}
+              # Seeds the memini memory filter's base_url valve (MEMINI_API_KEY
+              # comes from the secret via envFrom).
+              MEMINI_BASE_URL: http://memini.ai.svc.cluster.local:8080
               # First visit → sign up to create the admin account. Flip to false
               # afterwards (VPN-only, single user) if you want to lock it down.
               ENABLE_SIGNUP: true


### PR DESCRIPTION
GitOps half of the memini↔open-webui integration.

- ExternalSecret now pulls **MEMINI_API_KEY** (1Password `memini` item) alongside OPENAI_API_KEY, via explicit `data`/`property` refs.
- Helmrelease adds **MEMINI_BASE_URL**=`http://memini.ai.svc.cluster.local:8080`.

Once merged, the only remaining step is manual (UI, not GitOps): paste `integrations/openwebui/filter/memini_memory.py` from the memini repo into **Admin → Functions**; its `base_url` seeds from MEMINI_BASE_URL and the API key is read from MEMINI_API_KEY env (kept out of the Open WebUI DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)