### PR TITLE
feat(ai): add local Qwen3-14B (Ollama) as a litellm model

### DIFF
--- a/kubernetes/apps/ai/litellm/app/models/kustomization.yaml
+++ b/kubernetes/apps/ai/litellm/app/models/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./minimax.yaml
   - ./gpt-4-1.yaml
   - ./gpt-4-1-mini.yaml
+  - ./qwen3-14b.yaml

--- a/kubernetes/apps/ai/litellm/app/models/qwen3-14b.yaml
+++ b/kubernetes/apps/ai/litellm/app/models/qwen3-14b.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/litellm.home-operations.com/litellmmodel_v1alpha1.json
+apiVersion: litellm.home-operations.com/v1alpha1
+kind: LiteLLMModel
+metadata:
+  name: qwen3-14b
+spec:
+  modelName: qwen3-14b
+  params:
+    # Local Ollama via its OpenAI-compatible endpoint.
+    model: openai/qwen3:14b
+    apiBase: http://ollama.ai.svc.cluster.local:11434/v1
+    apiKey: ollama
+  info:
+    mode: chat
+    supportsFunctionCalling: true

--- a/kubernetes/apps/ai/ollama/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/ollama/app/helmrelease.yaml
@@ -29,7 +29,7 @@ spec:
                   command:
                     - /bin/sh
                     - -c
-                    - until ollama list >/dev/null 2>&1; do sleep 2; done; ollama pull bge-m3 && ollama run bge-m3 warmup >/dev/null 2>&1 || true
+                    - until ollama list >/dev/null 2>&1; do sleep 2; done; ollama pull bge-m3 && ollama pull qwen3:14b && ollama run bge-m3 warmup >/dev/null 2>&1 || true
             resources:
               requests:
                 cpu: 200m


### PR DESCRIPTION
Deploys **Qwen3-14B** for local, private, agentic inference on the RTX 5060 Ti.

- Ollama preloads `qwen3:14b` (alongside the pinned `bge-m3`; ~11GB VRAM together, leaves room for KV cache).
- Registered as a `LiteLLMModel` (`openai/qwen3:14b` via Ollama's `/v1`), so it appears in open-webui's model list and can back memini.

Chosen for best tool-calling reliability in the 16GB budget (see the model-choice discussion). First pull is ~9GB (once, cached on the PVC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)