### PR TITLE
chore(ai): cleanup — Hermes artifact, schema headers, reconcile health

### DIFF
--- a/kubernetes/apps/ai/litellm/app/job-init-db.yaml
+++ b/kubernetes/apps/ai/litellm/app/job-init-db.yaml
@@ -1,7 +1,6 @@
 ---
-# Idempotently provisions the litellm database + role in the shared CNPG
-# cluster. Runs as a Job because the operator-managed LiteLLMProxy Deployment
-# cannot host an init container.
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/batch/job_v1.json
+# Idempotent DB/role provisioning (operator Deployment has no init container).
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/kubernetes/apps/ai/litellm/app/mcpserver-toolhive.yaml
+++ b/kubernetes/apps/ai/litellm/app/mcpserver-toolhive.yaml
@@ -5,12 +5,7 @@ kind: LiteLLMMCPServer
 metadata:
   name: toolhive
 spec:
-  # Exposes the ToolHive VirtualMCPServer (which aggregates the kubectl/github/
-  # garmin/hass/unifi MCP servers) as a single MCP endpoint on the LiteLLM
-  # gateway, so any OpenAI-compatible client of litellm gets the tools.
-  # ToolHive stays the hosting/isolation/aggregation layer; litellm only exposes
-  # its aggregated endpoint. The VirtualMCPServer uses anonymous incoming auth,
-  # so no auth is configured here.
+  # Exposes the ToolHive VirtualMCPServer aggregate to litellm clients (anonymous in-cluster auth).
   alias: toolhive
   url: http://vmcp-mcp-gateway-internal.ai.svc.cluster.local:4483/mcp
   transport: http

--- a/kubernetes/apps/ai/litellm/ks.yaml
+++ b/kubernetes/apps/ai/litellm/ks.yaml
@@ -19,7 +19,7 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  wait: false
+  wait: true
   interval: 30m
   retryInterval: 1m
-  timeout: 5m
+  timeout: 10m

--- a/kubernetes/apps/ai/memini/app/pvc.yaml
+++ b/kubernetes/apps/ai/memini/app/pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/ai/memini/ks.yaml
+++ b/kubernetes/apps/ai/memini/ks.yaml
@@ -19,7 +19,7 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  wait: false
+  wait: true
   interval: 30m
   retryInterval: 1m
-  timeout: 5m
+  timeout: 10m

--- a/kubernetes/apps/ai/ollama/app/pvc.yaml
+++ b/kubernetes/apps/ai/ollama/app/pvc.yaml
@@ -1,4 +1,5 @@
 ---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -20,23 +20,14 @@ spec:
               repository: ghcr.io/open-webui/open-webui
               tag: v0.11.0
             env:
-              # Models come exclusively from the litellm gateway (OpenAI-compatible).
+              # Models come exclusively from the litellm gateway.
               ENABLE_OLLAMA_API: false
               ENABLE_OPENAI_API: true
               OPENAI_API_BASE_URL: http://litellm.ai.svc.cluster.local:4000/v1
               WEBUI_URL: https://chat.${CLUSTER_DOMAIN}
-              # Seeds the memini memory filter's base_url valve (MEMINI_API_KEY
-              # comes from the secret via envFrom).
               MEMINI_BASE_URL: http://memini.ai.svc.cluster.local:8080
-              # First visit → sign up to create the admin account. Flip to false
-              # afterwards (VPN-only, single user) if you want to lock it down.
               ENABLE_SIGNUP: true
-              # Native MCP tool server: point Open WebUI straight at the ToolHive
-              # VirtualMCPServer (aggregates garmin/home-assistant/unifi/kubectl/
-              # github). Streamable-HTTP is natively supported since v0.6.31 — no
-              # mcpo, no routing tools through litellm. Anonymous in-cluster auth.
-              # Seeds the DB on first boot (PersistentConfig); manage later in the
-              # admin UI (Admin Settings → External Tools).
+              # Native MCP tool server pointed at the ToolHive VMCP (seeds DB on first boot).
               TOOL_SERVER_CONNECTIONS: >-
                 [{"type":"mcp","url":"http://vmcp-mcp-gateway-internal.ai.svc.cluster.local:4483/mcp","path":"","auth_type":"none","config":{"enable":true},"info":{"id":"toolhive-vmcp","name":"ToolHive VMCP","description":"garmin, home-assistant, unifi, kubectl, github"}}]
             envFrom:

--- a/kubernetes/apps/ai/open-webui/app/pvc.yaml
+++ b/kubernetes/apps/ai/open-webui/app/pvc.yaml
@@ -1,12 +1,12 @@
 ---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/persistentvolumeclaim-v1.json
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: open-webui
 spec:
   accessModes: ["ReadWriteOnce"]
-  # Local NVMe: Open WebUI stores its state in a SQLite DB, which is unreliable
-  # over NFS (file locking). Keep it on local-hostpath instead of nfs-csi-sc.
+  # local NVMe: SQLite over NFS is unreliable (file locking)
   storageClassName: openebs-hostpath
   resources:
     requests:

--- a/kubernetes/apps/ai/open-webui/ks.yaml
+++ b/kubernetes/apps/ai/open-webui/ks.yaml
@@ -18,7 +18,7 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  wait: false
+  wait: true
   interval: 30m
   retryInterval: 1m
-  timeout: 5m
+  timeout: 10m

--- a/kubernetes/apps/ai/toolhive/config/app/mcpgroup.yaml
+++ b/kubernetes/apps/ai/toolhive/config/app/mcpgroup.yaml
@@ -4,4 +4,4 @@ kind: MCPGroup
 metadata:
   name: mcp-tools
 spec:
-  description: Aggregated MCP tools for Hermes agent
+  description: Aggregated MCP tools for LLM clients (open-webui, litellm)


### PR DESCRIPTION
Cleanup pass over the AI namespace.

- **Hermes artifact** — the only leftover was the MCPGroup `description` ("…for Hermes agent"); renamed to a generic one.
- **Schema headers** — added to the init-db Job + memini/ollama/open-webui PVCs. (ToolHive CRD manifests keep none — no published schema exists for `toolhive.stacklok.dev`.)
- **Reconcile health** — `wait: true` (+ 10m timeout) on litellm/memini/open-webui so Flux waits for real readiness (HelmReleases + the LiteLLMProxy `Ready` condition via kstatus) instead of marking ready on apply → correct `dependsOn` ordering. Ollama stays `wait: false` (its ~9GB model pull in postStart would trip a wait timeout on a fresh boot).
- **Comments** — trimmed the verbose blocks I'd added.

Note: the `kubectl-mcp` RBAC was reviewed — it's a correctly-scoped read-only ClusterRole co-located with the MCPServer; nothing to fold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)