### PR TITLE
feat(security): Kanidm SSO via KaniOp (phase 1 — operator + instance)

### DIFF
--- a/kubernetes/apps/security/kanidm/app/certificate.yaml
+++ b/kubernetes/apps/security/kanidm/app/certificate.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/cert-manager.io/certificate_v1.json
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kanidm-tls
+spec:
+  secretName: kanidm-tls
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+  commonName: idm.${CLUSTER_DOMAIN}
+  dnsNames:
+    - idm.${CLUSTER_DOMAIN}

--- a/kubernetes/apps/security/kanidm/app/identities.yaml
+++ b/kubernetes/apps/security/kanidm/app/identities.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmPersonAccount
+metadata:
+  name: dave
+spec:
+  kanidmRef:
+    name: kanidm
+  personAttributes:
+    displayname: Dave Altena
+    mail:
+      - daltena@schubergphilis.com
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: idm-admins
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - dave

--- a/kubernetes/apps/security/kanidm/app/kanidm.yaml
+++ b/kubernetes/apps/security/kanidm/app/kanidm.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: Kanidm
+metadata:
+  name: kanidm
+spec:
+  domain: idm.${CLUSTER_DOMAIN}
+  origin: https://idm.${CLUSTER_DOMAIN}
+  tlsSecretName: kanidm-tls
+  # Let OAuth2Client/Group/Person CRs live in the app namespaces they belong to.
+  oauth2ClientNamespaceSelector: {}
+  groupNamespaceSelector: {}
+  personNamespaceSelector: {}
+  replicaGroups:
+    - name: default
+      replicas: 1
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          memory: 512Mi
+  storage:
+    volumeClaimTemplate:
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: openebs-hostpath
+        resources:
+          requests:
+            storage: 2Gi
+  # Native Gateway API: the operator creates the HTTPRoute + BackendTLSPolicy.
+  gateway:
+    parentRefs:
+      - name: envoy-internal
+        namespace: network
+        sectionName: https
+    hostnames:
+      - idm.${CLUSTER_DOMAIN}
+    backendTlsPolicy:
+      validation:
+        hostname: idm.${CLUSTER_DOMAIN}
+        wellKnownCaCertificates: System

--- a/kubernetes/apps/security/kanidm/app/kustomization.yaml
+++ b/kubernetes/apps/security/kanidm/app/kustomization.yaml
@@ -3,9 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./onepassword-connect/ks.yaml
-  - ./external-secrets/ks.yaml
-  - ./kaniop/ks.yaml
-  - ./kanidm/ks.yaml
-  - ./keycloak/ks.yaml
+  - ./certificate.yaml
+  - ./kanidm.yaml
+  - ./identities.yaml

--- a/kubernetes/apps/security/kanidm/ks.yaml
+++ b/kubernetes/apps/security/kanidm/ks.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kanidm
+  namespace: flux-system
+spec:
+  targetNamespace: security
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: kaniop
+    - name: cert-manager-issuers
+  path: ./kubernetes/apps/security/kanidm/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m

--- a/kubernetes/apps/security/kaniop/app/helmrelease.yaml
+++ b/kubernetes/apps/security/kaniop/app/helmrelease.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://datreeio.github.io/CRDs-catalog/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kaniop
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: kaniop
+  install:
+    crds: CreateReplace
+  upgrade:
+    crds: CreateReplace
+  values:
+    replicas: 1
+    metrics:
+      enabled: true
+      serviceMonitor:
+        enabled: true

--- a/kubernetes/apps/security/kaniop/app/kustomization.yaml
+++ b/kubernetes/apps/security/kaniop/app/kustomization.yaml
@@ -3,9 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./namespace.yaml
-  - ./onepassword-connect/ks.yaml
-  - ./external-secrets/ks.yaml
-  - ./kaniop/ks.yaml
-  - ./kanidm/ks.yaml
-  - ./keycloak/ks.yaml
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/security/kaniop/app/ocirepository.yaml
+++ b/kubernetes/apps/security/kaniop/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.bjw-s.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: kaniop
+spec:
+  interval: 12h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.11.1
+  url: oci://ghcr.io/pando85/helm-charts/kaniop

--- a/kubernetes/apps/security/kaniop/ks.yaml
+++ b/kubernetes/apps/security/kaniop/ks.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kaniop
+  namespace: flux-system
+spec:
+  targetNamespace: security
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  path: ./kubernetes/apps/security/kaniop/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m


### PR DESCRIPTION
Phase 1 of migrating SSO to **Kanidm** (small-scale, passkey-native), managed by the **KaniOp** operator.

- **kaniop** operator (chart `0.11.1`, CRDs via CreateReplace) in `security`.
- **Kanidm** instance `idm.${CLUSTER_DOMAIN}`: TLS from a cert-manager cert (letsencrypt-production DNS-01), 2Gi on openebs-hostpath, exposed via kaniop's native `spec.gateway` → operator-managed HTTPRoute + BackendTLSPolicy on `envoy-internal` (VPN-only; Kanidm serves HTTPS on :8443). Namespace selectors open so app `KanidmOAuth2Client` CRs can live in their own namespaces.
- My `KanidmPersonAccount` + `idm-admins` `KanidmGroup`.

Admin creds land in the operator-created `kanidm-admin-passwords` secret. After this, I enroll a passkey via the Kanidm UI.

**Next:** phase 2 = `KanidmOAuth2Client` + wire open-webui & Grafana OIDC; phase 3 = remove Keycloak. Keycloak stays untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)