### PR TITLE
feat: open-webui + Grafana OIDC via Kanidm (phase 2)

### DIFF
--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -27,6 +27,23 @@ spec:
               WEBUI_URL: https://chat.${CLUSTER_DOMAIN}
               MEMINI_BASE_URL: http://memini.ai.svc.cluster.local:8080
               ENABLE_SIGNUP: true
+              # SSO via Kanidm (OIDC); client id/secret from the KanidmOAuth2Client secret.
+              ENABLE_OAUTH_SIGNUP: true
+              OAUTH_MERGE_ACCOUNTS_BY_EMAIL: true
+              OAUTH_PROVIDER_NAME: Kanidm
+              OAUTH_SCOPES: openid email profile
+              OPENID_PROVIDER_URL: https://idm.${CLUSTER_DOMAIN}/oauth2/openid/open-webui/.well-known/openid-configuration
+              OPENID_REDIRECT_URI: https://chat.${CLUSTER_DOMAIN}/oauth/oidc/callback
+              OAUTH_CLIENT_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: open-webui-kanidm-oauth2-credentials
+                    key: CLIENT_ID
+              OAUTH_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: open-webui-kanidm-oauth2-credentials
+                    key: CLIENT_SECRET
               # Native MCP tool server pointed at the ToolHive VMCP (seeds DB on first boot).
               TOOL_SERVER_CONNECTIONS: >-
                 [{"type":"mcp","url":"http://vmcp-mcp-gateway-internal.ai.svc.cluster.local:4483/mcp","path":"","auth_type":"none","config":{"enable":true},"info":{"id":"toolhive-vmcp","name":"ToolHive VMCP","description":"garmin, home-assistant, unifi, kubectl, github"}}]

--- a/kubernetes/apps/ai/open-webui/ks.yaml
+++ b/kubernetes/apps/ai/open-webui/ks.yaml
@@ -13,8 +13,18 @@ spec:
   dependsOn:
     - name: external-secrets-stores
     - name: litellm
+    - name: kanidm
+  components:
+    - ../../../../components/kanidm-oauth2
   path: ./kubernetes/apps/ai/open-webui/app
   prune: true
+  postBuild:
+    substitute:
+      APP: open-webui
+      OAUTH2_DISPLAYNAME: Open WebUI
+      OAUTH2_HOST: chat
+      OAUTH2_REDIRECT_PATH: /oauth/oidc/callback
+      OAUTH2_GROUP: open-webui-users
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/observability/grafana-operator/instance/grafana.yaml
+++ b/kubernetes/apps/observability/grafana-operator/instance/grafana.yaml
@@ -20,6 +20,17 @@ spec:
       org_id: "1"
       org_name: "Main Org."
       org_role: "Viewer"
+    auth.generic_oauth:
+      enabled: "true"
+      name: Kanidm
+      scopes: "openid email profile groups"
+      auth_url: https://idm.${CLUSTER_DOMAIN}/ui/oauth2
+      token_url: https://idm.${CLUSTER_DOMAIN}/oauth2/token
+      api_url: https://idm.${CLUSTER_DOMAIN}/oauth2/openid/grafana/userinfo
+      use_pkce: "true"
+      role_attribute_path: "contains(grafana_role[*], 'Admin') && 'Admin' || 'Viewer'"
+      role_attribute_strict: "false"
+      allow_assign_grafana_admin: "true"
     date_formats:
       use_browser_locale: "true"
     explore:
@@ -59,6 +70,16 @@ spec:
                     secretKeyRef:
                       name: grafana-admin-credentials
                       key: GF_SECURITY_ADMIN_PASSWORD
+                - name: GF_AUTH_GENERIC_OAUTH_CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-kanidm-oauth2-credentials
+                      key: CLIENT_ID
+                - name: GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      name: grafana-kanidm-oauth2-credentials
+                      key: CLIENT_SECRET
               resources:
                 requests:
                   cpu: 10m

--- a/kubernetes/apps/observability/grafana-operator/instance/kustomization.yaml
+++ b/kubernetes/apps/observability/grafana-operator/instance/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: observability
 resources:
   - ./externalsecret.yaml
+  - ./oauth2client.yaml
   - ./grafana.yaml
   - ./grafanadatasource.yaml
   - ./servicemonitor.yaml

--- a/kubernetes/apps/observability/grafana-operator/instance/oauth2client.yaml
+++ b/kubernetes/apps/observability/grafana-operator/instance/oauth2client.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: grafana
+spec:
+  kanidmRef:
+    name: kanidm
+    namespace: security
+  displayname: Grafana
+  origin: https://grafana.${CLUSTER_DOMAIN}
+  redirectUrl:
+    - https://grafana.${CLUSTER_DOMAIN}/login/generic_oauth
+  scopeMap:
+    - group: grafana-users
+      scopes:
+        - openid
+        - email
+        - profile
+        - groups
+  claimMap:
+    - name: grafana_role
+      joinStrategy: array
+      valuesMap:
+        - group: grafana-admins
+          values:
+            - Admin

--- a/kubernetes/apps/observability/grafana-operator/ks.yaml
+++ b/kubernetes/apps/observability/grafana-operator/ks.yaml
@@ -34,6 +34,7 @@ spec:
   dependsOn:
     - name: grafana-operator
     - name: prometheus-operator-crds
+    - name: kanidm
   interval: 10m
   path: ./kubernetes/apps/observability/grafana-operator/instance
   prune: true

--- a/kubernetes/apps/security/kanidm/app/identities.yaml
+++ b/kubernetes/apps/security/kanidm/app/identities.yaml
@@ -20,3 +20,33 @@ spec:
     name: kanidm
   members:
     - dave
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: open-webui-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - dave
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: grafana-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - dave
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: grafana-admins
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - dave

--- a/kubernetes/components/kanidm-oauth2/kustomization.yaml
+++ b/kubernetes/components/kanidm-oauth2/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./oauth2client.yaml

--- a/kubernetes/components/kanidm-oauth2/oauth2client.yaml
+++ b/kubernetes/components/kanidm-oauth2/oauth2client.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: ${APP}
+spec:
+  kanidmRef:
+    name: kanidm
+    namespace: security
+  displayname: ${OAUTH2_DISPLAYNAME}
+  origin: https://${OAUTH2_HOST}.${CLUSTER_DOMAIN}
+  redirectUrl:
+    - https://${OAUTH2_HOST}.${CLUSTER_DOMAIN}${OAUTH2_REDIRECT_PATH}
+  scopeMap:
+    - group: ${OAUTH2_GROUP}
+      scopes:
+        - openid
+        - email
+        - profile


### PR DESCRIPTION
Phase 2: wire apps to the Kanidm SSO, with a reusable pattern.

- **`components/kanidm-oauth2`** — a Kustomize Component that templates a `KanidmOAuth2Client` from `postBuild.substitute` vars (`APP`, `OAUTH2_HOST`, `OAUTH2_REDIRECT_PATH`, `OAUTH2_GROUP`, `OAUTH2_DISPLAYNAME`). Any simple OIDC app now gets SSO by adding `components:` + a few vars to its ks. First component in the repo.
- **open-webui** — uses the component (group `open-webui-users`) + OIDC env; client id/secret from the operator-created `open-webui-kanidm-oauth2-credentials` secret.
- **Grafana** — a direct `KanidmOAuth2Client` (needs `claimMap` for role mapping: `grafana-admins → Admin`) + `auth.generic_oauth` config; client id/secret via env from `grafana-kanidm-oauth2-credentials`.
- New `KanidmGroup`s (open-webui-users, grafana-users, grafana-admins) with my account. Both app Kustomizations now `dependsOn: kanidm`.

App-side OIDC config stays per-app (open-webui env vs Grafana ini) — can't be componentized.

**Next:** phase 3 removes Keycloak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)