### PR TITLE
fix(ai): enable PKCE (S256) for open-webui OIDC

### DIFF
--- a/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/open-webui/app/helmrelease.yaml
@@ -32,6 +32,7 @@ spec:
               OAUTH_MERGE_ACCOUNTS_BY_EMAIL: true
               OAUTH_PROVIDER_NAME: Kanidm
               OAUTH_SCOPES: openid email profile
+              OAUTH_CODE_CHALLENGE_METHOD: S256
               OPENID_PROVIDER_URL: https://idm.${CLUSTER_DOMAIN}/oauth2/openid/open-webui/.well-known/openid-configuration
               OPENID_REDIRECT_URI: https://chat.${CLUSTER_DOMAIN}/oauth/oidc/callback
               OAUTH_CLIENT_ID:


### PR DESCRIPTION
Kanidm enforces PKCE; open-webui wasn't sending a code challenge → `No PKCE code challenge ... invalid_request` on login. Set `OAUTH_CODE_CHALLENGE_METHOD=S256` so open-webui does PKCE (secure fix, rather than disabling PKCE on the Kanidm client). Grafana already uses PKCE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)