### PR TITLE
feat(sso): mealie, actual, forgejo, paperless behind Kanidm OIDC

### DIFF
--- a/kubernetes/apps/security/kanidm/app/identities.yaml
+++ b/kubernetes/apps/security/kanidm/app/identities.yaml
@@ -50,3 +50,43 @@ spec:
     name: kanidm
   members:
     - dave
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: mealie-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - dave
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: actual-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - dave
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: forgejo-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - dave
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmGroup
+metadata:
+  name: paperless-users
+spec:
+  kanidmRef:
+    name: kanidm
+  members:
+    - dave

--- a/kubernetes/apps/selfhosted/actual-finance/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/actual-finance/app/helmrelease.yaml
@@ -28,6 +28,19 @@ spec:
               tag: 26.8.0
             env:
               ACTUAL_PORT: &httpPort 5006
+              # SSO via Kanidm (OIDC, confidential client + PKCE)
+              ACTUAL_OPENID_DISCOVERY_URL: https://idm.${CLUSTER_DOMAIN}/oauth2/openid/actual/.well-known/openid-configuration
+              ACTUAL_OPENID_SERVER_HOSTNAME: https://finance.${CLUSTER_DOMAIN}
+              ACTUAL_OPENID_CLIENT_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: actual-kanidm-oauth2-credentials
+                    key: CLIENT_ID
+              ACTUAL_OPENID_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: actual-kanidm-oauth2-credentials
+                    key: CLIENT_SECRET
             probes:
               liveness:
                 enabled: true

--- a/kubernetes/apps/selfhosted/actual-finance/ks.yaml
+++ b/kubernetes/apps/selfhosted/actual-finance/ks.yaml
@@ -10,8 +10,19 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  dependsOn:
+    - name: kanidm
+  components:
+    - ../../../../components/kanidm-oauth2
   path: ./kubernetes/apps/selfhosted/actual-finance/app
   prune: true
+  postBuild:
+    substitute:
+      APP: actual
+      OAUTH2_DISPLAYNAME: Actual
+      OAUTH2_HOST: finance
+      OAUTH2_REDIRECT_PATH: /openid/callback
+      OAUTH2_GROUP: actual-users
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/selfhosted/forgejo/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/forgejo/app/helmrelease.yaml
@@ -43,6 +43,14 @@ spec:
             secretKeyRef:
               name: forgejo-secret
               key: INIT_POSTGRES_PASS
+      # SSO via Kanidm; client id/secret from the KanidmOAuth2Client secret
+      # (aliased to key/secret). Provider name "Kanidm" → callback /user/oauth2/Kanidm/callback.
+      oauth:
+        - name: Kanidm
+          provider: openidConnect
+          autoDiscoverUrl: https://idm.${CLUSTER_DOMAIN}/oauth2/openid/forgejo/.well-known/openid-configuration
+          scopes: openid email profile
+          existingSecret: forgejo-kanidm-oauth2-credentials
       metrics:
         enabled: true
         serviceMonitor:
@@ -67,6 +75,10 @@ spec:
           TYPE: level
         service:
           DISABLE_REGISTRATION: true
+        oauth2_client:
+          ENABLE_AUTO_REGISTRATION: true
+          ACCOUNT_LINKING: auto
+          UPDATE_AVATAR: true
         actions:
           ENABLED: true
         mirror:

--- a/kubernetes/apps/selfhosted/forgejo/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/forgejo/app/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - ./ocirepository.yaml
   - ./httproute.yaml
   - ./postgres-init-job.yaml
+  - ./oauth2client.yaml

--- a/kubernetes/apps/selfhosted/forgejo/app/oauth2client.yaml
+++ b/kubernetes/apps/selfhosted/forgejo/app/oauth2client.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: forgejo
+spec:
+  kanidmRef:
+    name: kanidm
+    namespace: security
+  displayname: Forgejo
+  origin: https://git.${CLUSTER_DOMAIN}
+  redirectUrl:
+    - https://git.${CLUSTER_DOMAIN}/user/oauth2/Kanidm/callback
+  scopeMap:
+    - group: forgejo-users
+      scopes:
+        - openid
+        - email
+        - profile
+  # Forgejo's goth OIDC client does not send PKCE; the chart reads key/secret.
+  allowInsecureClientDisablePkce: true
+  secretKeyAliases:
+    clientId:
+      - key
+    clientSecret:
+      - secret

--- a/kubernetes/apps/selfhosted/forgejo/ks.yaml
+++ b/kubernetes/apps/selfhosted/forgejo/ks.yaml
@@ -13,6 +13,7 @@ spec:
   dependsOn:
     - name: external-secrets-stores
     - name: cnpg-cluster
+    - name: kanidm
   path: ./kubernetes/apps/selfhosted/forgejo/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/selfhosted/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/mealie/app/helmrelease.yaml
@@ -61,6 +61,22 @@ spec:
               SMTP_AUTH_STRATEGY: TLS
               SMTP_USER: mealie@${CLUSTER_DOMAIN}
               # OPENAI_BASE_URL: https://openrouter.ai/api/v1
+              # SSO via Kanidm (OIDC, confidential client + PKCE)
+              OIDC_AUTH_ENABLED: "true"
+              OIDC_PROVIDER_NAME: Kanidm
+              OIDC_CONFIGURATION_URL: https://idm.${CLUSTER_DOMAIN}/oauth2/openid/mealie/.well-known/openid-configuration
+              OIDC_SIGNUP_ENABLED: "true"
+              OIDC_USER_CLAIM: email
+              OIDC_CLIENT_ID:
+                valueFrom:
+                  secretKeyRef:
+                    name: mealie-kanidm-oauth2-credentials
+                    key: CLIENT_ID
+              OIDC_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: mealie-kanidm-oauth2-credentials
+                    key: CLIENT_SECRET
             envFrom: *envFrom
             resources:
               requests:

--- a/kubernetes/apps/selfhosted/mealie/ks.yaml
+++ b/kubernetes/apps/selfhosted/mealie/ks.yaml
@@ -13,8 +13,18 @@ spec:
   dependsOn:
     - name: external-secrets-stores
     - name: cnpg-cluster
+    - name: kanidm
+  components:
+    - ../../../../components/kanidm-oauth2
   path: ./kubernetes/apps/selfhosted/mealie/app
   prune: true
+  postBuild:
+    substitute:
+      APP: mealie
+      OAUTH2_DISPLAYNAME: Mealie
+      OAUTH2_HOST: mealie
+      OAUTH2_REDIRECT_PATH: /login
+      OAUTH2_GROUP: mealie-users
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/kubernetes/apps/selfhosted/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/paperless/app/helmrelease.yaml
@@ -49,6 +49,11 @@ spec:
               PAPERLESS_REDIS: redis://paperless-redis.selfhosted.svc.cluster.local:6379
               # Configure user permissions
               USERMAP_GID: "100"
+              # SSO via Kanidm (OIDC, public client + PKCE via allauth)
+              PAPERLESS_APPS: allauth.socialaccount.providers.openid_connect
+              PAPERLESS_SOCIAL_AUTO_SIGNUP: "true"
+              PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS: "true"
+              PAPERLESS_SOCIALACCOUNT_PROVIDERS: '{"openid_connect":{"OAUTH_PKCE_ENABLED":true,"APPS":[{"provider_id":"kanidm","name":"Kanidm","client_id":"paperless","secret":"","settings":{"server_url":"https://idm.${CLUSTER_DOMAIN}/oauth2/openid/paperless/.well-known/openid-configuration"}}],"SCOPE":["openid","email","profile"]}}'
               # Configure admin user
               PAPERLESS_ADMIN_USER:
                 valueFrom:

--- a/kubernetes/apps/selfhosted/paperless/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/paperless/app/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./oauth2client.yaml

--- a/kubernetes/apps/selfhosted/paperless/app/oauth2client.yaml
+++ b/kubernetes/apps/selfhosted/paperless/app/oauth2client.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: paperless
+spec:
+  kanidmRef:
+    name: kanidm
+    namespace: security
+  displayname: Paperless
+  # Public client: allauth uses PKCE with no client secret; client_id is
+  # inlined in PAPERLESS_SOCIALACCOUNT_PROVIDERS (client_id == client name).
+  public: true
+  origin: https://paperless.${CLUSTER_DOMAIN}
+  redirectUrl:
+    - https://paperless.${CLUSTER_DOMAIN}/accounts/oidc/kanidm/login/callback/
+  scopeMap:
+    - group: paperless-users
+      scopes:
+        - openid
+        - email
+        - profile

--- a/kubernetes/apps/selfhosted/paperless/ks.yaml
+++ b/kubernetes/apps/selfhosted/paperless/ks.yaml
@@ -12,6 +12,7 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: external-secrets-stores
+    - name: kanidm
   path: ./kubernetes/apps/selfhosted/paperless/app
   prune: true
   sourceRef:


### PR DESCRIPTION
Extends Kanidm SSO to the four daily-use web apps. Each is gated by a per-app Kanidm group (`*-users`, member: dave) and depends on the `kanidm` Kustomization.

| App | Client | PKCE | Redirect | Wiring |
|-----|--------|------|----------|--------|
| mealie | confidential (component) | ✅ | `/login` | `OIDC_*` env from `mealie-kanidm-oauth2-credentials` |
| actual | confidential (component) | ✅ | `/openid/callback` | `ACTUAL_OPENID_*` env from `actual-kanidm-oauth2-credentials` |
| forgejo | confidential (direct) | ❌ disabled (goth) | `/user/oauth2/Kanidm/callback` | `gitea.oauth` + `existingSecret` (CLIENT_ID/SECRET aliased to `key`/`secret`) |
| paperless | **public** (direct) | ✅ | `/accounts/oidc/kanidm/login/callback/` | `PAPERLESS_SOCIALACCOUNT_PROVIDERS` (client_id inline, no secret) |

Notes:
- Verified against upstream docs (Mealie OIDC v2, Actual OpenID, Forgejo helm `gitea.oauth`, paperless-ngx allauth).
- forgejo enables `oauth2_client` auto-registration + account-linking by email.
- Each login still needs a one-time passkey verification after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)