### PR TITLE
fix(sso): actual needs RS256 id tokens (jwtLegacyCryptoEnable)

### DIFF
--- a/kubernetes/apps/selfhosted/actual-finance/app/kustomization.yaml
+++ b/kubernetes/apps/selfhosted/actual-finance/app/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - ./pvc.yaml
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./oauth2client.yaml

--- a/kubernetes/apps/selfhosted/actual-finance/app/oauth2client.yaml
+++ b/kubernetes/apps/selfhosted/actual-finance/app/oauth2client.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kaniop.rs/v1beta1
+kind: KanidmOAuth2Client
+metadata:
+  name: actual
+spec:
+  kanidmRef:
+    name: kanidm
+    namespace: security
+  displayname: Actual
+  origin: https://finance.${CLUSTER_DOMAIN}
+  redirectUrl:
+    - https://finance.${CLUSTER_DOMAIN}/openid/callback
+  scopeMap:
+    - group: actual-users
+      scopes:
+        - openid
+        - email
+        - profile
+  # Actual's openid-client only accepts RS256; Kanidm signs ES256 by default.
+  jwtLegacyCryptoEnable: true

--- a/kubernetes/apps/selfhosted/actual-finance/ks.yaml
+++ b/kubernetes/apps/selfhosted/actual-finance/ks.yaml
@@ -12,17 +12,8 @@ spec:
       app.kubernetes.io/name: *app
   dependsOn:
     - name: kanidm
-  components:
-    - ../../../../components/kanidm-oauth2
   path: ./kubernetes/apps/selfhosted/actual-finance/app
   prune: true
-  postBuild:
-    substitute:
-      APP: actual
-      OAUTH2_DISPLAYNAME: Actual
-      OAUTH2_HOST: finance
-      OAUTH2_REDIRECT_PATH: /openid/callback
-      OAUTH2_GROUP: actual-users
   sourceRef:
     kind: GitRepository
     name: flux-system


### PR DESCRIPTION
Actual login failed with `openid-grant-failed` → `unexpected JWT alg received, expected RS256, got: ES256`. Actual's `openid-client` only accepts RS256; Kanidm signs ES256 by default.

Moves actual off the shared `kanidm-oauth2` component to a direct `KanidmOAuth2Client` with `jwtLegacyCryptoEnable: true` (RS256). Other apps keep ES256 (open-webui/grafana already verified working with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)