### PR TITLE
fix(sso): forgejo username from short name, not spn

### DIFF
--- a/kubernetes/apps/selfhosted/forgejo/app/oauth2client.yaml
+++ b/kubernetes/apps/selfhosted/forgejo/app/oauth2client.yaml
@@ -19,6 +19,9 @@ spec:
         - profile
   # Forgejo's goth OIDC client does not send PKCE; the chart reads key/secret.
   allowInsecureClientDisablePkce: true
+  # preferred_username = "dave" (short name), not the spn "dave@idm..." —
+  # Forgejo usernames may not contain "@".
+  preferShortUsername: true
   secretKeyAliases:
     clientId:
       - key


### PR DESCRIPTION
Forgejo OAuth succeeded but user auto-creation failed: `CreateUser: name is invalid [dave@idm.altena.io]: must be valid alpha or numeric or dash(-_) or dot characters`. Kanidm sent the spn as `preferred_username`.

Sets `preferShortUsername: true` on the forgejo client → `preferred_username` becomes `dave`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)