### PR TITLE
fix(sso): disable paperless social signups

### DIFF
--- a/kubernetes/apps/selfhosted/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/selfhosted/paperless/app/helmrelease.yaml
@@ -51,8 +51,9 @@ spec:
               USERMAP_GID: "100"
               # SSO via Kanidm (OIDC, public client + PKCE via allauth)
               PAPERLESS_APPS: allauth.socialaccount.providers.openid_connect
-              PAPERLESS_SOCIAL_AUTO_SIGNUP: "true"
-              PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS: "true"
+              # Signups off: the dave account is already linked; avoids stray duplicate SSO users.
+              PAPERLESS_SOCIAL_AUTO_SIGNUP: "false"
+              PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS: "false"
               PAPERLESS_SOCIALACCOUNT_PROVIDERS: '{"openid_connect":{"OAUTH_PKCE_ENABLED":true,"APPS":[{"provider_id":"kanidm","name":"Kanidm","client_id":"paperless","secret":"","settings":{"server_url":"https://idm.${CLUSTER_DOMAIN}/oauth2/openid/paperless/.well-known/openid-configuration"}}],"SCOPE":["openid","email","profile"]}}'
               # Configure admin user
               PAPERLESS_ADMIN_USER:


### PR DESCRIPTION
## What

Set `PAPERLESS_SOCIAL_AUTO_SIGNUP` and `PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS` to `false` for paperless.

## Why

On the first Kanidm SSO login, allauth auto-created a **second, permission-less** paperless user `dave@idm.altena.io` because the local admin username `dave` was already taken. That account owned no documents and lacked permissions → `403` on `/api/ui_settings/` and an empty UI.

The Kanidm social account is now linked (in the DB) to the existing superuser `dave`, so social signups are no longer needed and only risk creating more stray/duplicate users. Paperless does not expose a safe "match existing user by verified email" setting (the underlying allauth `SOCIALACCOUNT_EMAIL_AUTHENTICATION` has account-takeover implications), so disabling signups is the supported, low-risk hardening.

## Safety

- `dave`'s SSO login keeps working — the social account is already connected; signup settings only affect *creating* new accounts.
- Regular login remains enabled as break-glass via `PAPERLESS_ADMIN_USER`/`PAPERLESS_ADMIN_PASSWORD`.

Source: [paperless-ngx configuration docs](https://docs.paperless-ngx.com/configuration/) (`PAPERLESS_SOCIAL_AUTO_SIGNUP`, `PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)